### PR TITLE
feat(reconciliation): 优化对账页面交互并增加付款人搜索功能

### DIFF
--- a/backend/api/bank_statement_api.py
+++ b/backend/api/bank_statement_api.py
@@ -142,3 +142,23 @@ def cancel_allocation(bank_transaction_id):
         return jsonify(result), 400
 
     return jsonify(result), 200
+
+@bank_statement_api.route("/api/bank-transactions/<bank_transaction_id>/ignore", methods=["POST"])
+@jwt_required()
+def ignore_transaction_route(bank_transaction_id):
+    operator_id = get_jwt_identity()
+    service = BankStatementService()
+    result = service.ignore_transaction(bank_transaction_id, operator_id)
+    if result.get("error"):
+        return jsonify(result), 400
+    return jsonify(result), 200
+
+@bank_statement_api.route("/api/bank-transactions/<bank_transaction_id>/unignore", methods=["POST"])
+@jwt_required()
+def unignore_transaction_route(bank_transaction_id):
+    operator_id = get_jwt_identity()
+    service = BankStatementService()
+    result = service.unignore_transaction(bank_transaction_id, operator_id)
+    if result.get("error"):
+        return jsonify(result), 400
+    return jsonify(result), 200

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -311,6 +311,7 @@ const BankStatementUploader = lazy(() => import('./components/BankStatementUploa
 const ReconciliationPage = lazy(() => import('./components/ReconciliationPage'));
 // 仪表盘
 const DashboardPage = lazy(() => import('./components/DashboardPage'));
+const SankeyPreview = lazy(() => import('./components/SankeyPreview')); // Sankey Preview
 
 
 // --- 5. App 组件主体 ---
@@ -363,6 +364,7 @@ function App() {
         {/* 应用简单布局的路由 */}
         <Route element={<SimpleLayoutInternal />}>
           {/* --- 5. 使用 Suspense 包裹懒加载组件 --- */}
+          <Route path="/sankey-preview" element={<Suspense fallback={<LoadingFallback />}><SankeyPreview /></Suspense>} />
           <Route path="/login" element={<Suspense fallback={<LoadingFallback />}> <LoginPage /> </Suspense>} />
           <Route path="/client-evaluation/:userId" element={<Suspense fallback={<LoadingFallback />}> <ClientEvaluation /> </Suspense>} />
           <Route path="/public-employee-self-evaluation" element={<Suspense fallback={<LoadingFallback />}> <PublicEmployeeSelfEvaluation /> </Suspense>} />

--- a/frontend/src/api/reconciliationApi.js
+++ b/frontend/src/api/reconciliationApi.js
@@ -26,5 +26,11 @@ export const reconciliationApi = {
     },
     cancelAllocation: (transactionId) => {
         return api.post(`/bank-transactions/${transactionId}/cancel-allocation`);
+    },
+    ignoreTransaction: (transactionId) => {
+        return api.post(`/bank-transactions/${transactionId}/ignore`);
+    },
+    unignoreTransaction: (transactionId) => {
+        return api.post(`/bank-transactions/${transactionId}/unignore`);
     }
 };

--- a/frontend/src/components/SankeyPreview.jsx
+++ b/frontend/src/components/SankeyPreview.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Sankey, ResponsiveContainer, Tooltip, Layer, Rectangle } from 'recharts';
+
+// 虚拟数据，模拟资金流向
+const data = {
+  nodes: [
+    { name: "客户A回款 (¥800)" },
+    { name: "客户B回款 (¥1000)" },
+    { name: "张三-7月账单" },
+    { name: "李四-7月账单" },
+    { name: "张三-8月账单" },
+  ],
+  links: [
+    { source: 0, target: 2, value: 500 },
+    { source: 0, target: 4, value: 300 },
+    { source: 1, target: 3, value: 800 },
+    { source: 1, target: 4, value: 200 },
+  ],
+};
+
+// 自定义节点组件，使其更美观
+const CustomNode = ({ x, y, width, height, index, payload }) => {
+  return (
+    <Layer key={`CustomNode${index}`}>
+      <Rectangle
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill="#26A69A" // 使用主题色
+        fillOpacity="1"
+      />
+      <text
+        textAnchor="middle"
+        x={x + width / 2}
+        y={y + height / 2 + 4} // 垂直居中
+        fill="#fff" // 白色字体
+        fontSize="14"
+      >
+        {payload.name}
+      </text>
+    </Layer>
+  );
+};
+
+const SankeyPreview = () => {
+  return (
+    <div style={{ width: '100%', height: 600, backgroundColor: '#f7fafc', padding: '20px' }}>
+      <h2 style={{ textAlign: 'center', color: '#525f7f' }}>回款分配预览 (虚拟数据)</h2>
+      <ResponsiveContainer width="100%" height="100%">
+        <Sankey
+          data={data}
+          nodePadding={50}
+          margin={{
+            left: 150,
+            right: 150,
+            top: 40,
+            bottom: 40,
+          }}
+          link={{ stroke: '#B0BEC5', strokeOpacity: 0.5 }}
+          node={<CustomNode />}
+        >
+          <Tooltip 
+            cursor={{ stroke: 'red', strokeWidth: 2 }}
+            formatter={(value, name, props) => {
+              const { source, target } = props.payload;
+              return `${source.name} -> ${target.name}: ¥${value}`;
+            }}
+          />
+        </Sankey>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default SankeyPreview;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -11,7 +11,8 @@ import {
   QuestionAnswer as QuestionAnswerIcon, Assignment as AssignmentIcon, AssignmentTurnedIn as AssignmentTurnedInIcon,
   People as PeopleIcon, Menu as MenuIcon, ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon, Settings as SettingsIcon, Api as ApiIcon, AccountBalanceWallet as AccountBalanceWalletIcon,
-  Description as DescriptionIcon, History as HistoryIcon, ExpandLess, ExpandMore, Warning as WarningIcon
+  Description as DescriptionIcon, History as HistoryIcon, ExpandLess, ExpandMore, Warning as WarningIcon,
+  Payment as PaymentIcon, Payments as PaymentsIcon
 } from '@mui/icons-material';
 import logo from '../assets/logo.svg';
 import UserInfo from './UserInfo';
@@ -51,7 +52,8 @@ export const allMenuItems = [
     path: '/billing/reconcile-group', // Placeholder path for the group
     adminOnly: true,
     subItems: [
-      { text: '客户回款', path: '/billing/reconcile', adminOnly: true },
+      { text: '客户回款', icon: <PaymentIcon />, path: '/billing/reconcile', adminOnly: true },
+      { text: '付员工工资', icon: <PaymentsIcon />, path: '/billing/salary-payment', adminOnly: true },
     ]
   },
   { text: '我的课程', icon: <SchoolIcon />, path: '/my-courses', adminOnly: false },

--- a/reconciliation_workbench_mockup.html
+++ b/reconciliation_workbench_mockup.html
@@ -1,0 +1,256 @@
+
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>回款对账工作台 - 预览</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700&display=swap');
+        body {
+            font-family: 'Noto Sans SC', sans-serif;
+        }
+        .kpi-card {
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .kpi-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+        }
+        .transaction-item.selected {
+            background-color: #E0F2F1; /* 呼应主题的浅青色 */
+            border-right: 4px solid #26A69A; /* 呼应主题的强调色 */
+        }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+
+    <div class="container mx-auto p-4 md:p-8">
+        
+        <!-- 页面标题 -->
+        <header class="mb-8">
+            <h1 class="text-3xl font-bold text-gray-900">回款对账工作台</h1>
+            <p class="text-gray-500 mt-1">2025年10月</p>
+        </header>
+
+        <!-- 核心指标 (KPIs) -->
+        <section class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            <div class="kpi-card bg-white p-6 rounded-lg shadow-md border-l-4 border-blue-500">
+                <div class="flex justify-between items-center">
+                    <h2 class="text-gray-500 font-medium">总回款额</h2>
+                    <i class="fas fa-dollar-sign text-blue-500 text-2xl"></i>
+                </div>
+                <p class="text-4xl font-bold mt-2">¥1,800.00</p>
+            </div>
+            <div class="kpi-card bg-white p-6 rounded-lg shadow-md border-l-4 border-green-500">
+                <div class="flex justify-between items-center">
+                    <h2 class="text-gray-500 font-medium">已分配额</h2>
+                    <i class="fas fa-check-circle text-green-500 text-2xl"></i>
+                </div>
+                <p class="text-4xl font-bold mt-2">¥1,800.00</p>
+            </div>
+            <div class="kpi-card bg-white p-6 rounded-lg shadow-md border-l-4 border-orange-500">
+                <div class="flex justify-between items-center">
+                    <h2 class="text-gray-500 font-medium">未分配额</h2>
+                    <i class="fas fa-hourglass-half text-orange-500 text-2xl"></i>
+                </div>
+                <p class="text-4xl font-bold mt-2 text-orange-500">¥0.00</p>
+            </div>
+        </section>
+
+        <!-- 分配进度条 -->
+        <div class="mb-8 bg-white p-4 rounded-lg shadow-md">
+            <h3 class="font-medium mb-2">分配进度</h3>
+            <div class="w-full bg-gray-200 rounded-full h-4">
+                <div class="bg-green-500 h-4 rounded-full text-center text-white text-xs" style="width: 100%">100%</div>
+            </div>
+        </div>
+
+        <!-- 两栏布局 -->
+        <main class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            
+            <!-- 左侧：资金来源 -->
+            <aside class="lg:col-span-1 bg-white rounded-lg shadow-md overflow-hidden">
+                <div class="p-4 border-b">
+                    <h2 class="text-xl font-semibold">资金来源 (回款记录)</h2>
+                </div>
+                <div id="transaction-list" class="divide-y divide-gray-200">
+                    <!-- 虚拟数据将由JS注入 -->
+                </div>
+            </aside>
+
+            <!-- 右侧：资金去向 -->
+            <section id="allocation-details" class="lg:col-span-2 bg-white rounded-lg shadow-md">
+                <!-- 详情将由JS注入 -->
+            </section>
+
+        </main>
+    </div>
+
+    <script>
+        const dummyData = {
+            transaction1: {
+                payer: '客户A',
+                amount: 800.00,
+                date: '2025-10-05',
+                status: '已全部分配',
+                statusColor: 'green',
+                allocations: [
+                    {
+                        amount: 500.00,
+                        bill: '7月账单',
+                        contract: '育儿嫂合同',
+                        customer: '夏梦',
+                        employee: '张三'
+                    },
+                    {
+                        amount: 300.00,
+                        bill: '8月账单',
+                        contract: '育儿嫂合同',
+                        customer: '夏梦',
+                        employee: '张三'
+                    }
+                ]
+            },
+            transaction2: {
+                payer: '客户B',
+                amount: 1000.00,
+                date: '2025-10-08',
+                status: '部分分配',
+                statusColor: 'yellow',
+                allocations: [
+                    {
+                        amount: 800.00,
+                        bill: '7月账单',
+                        contract: '月嫂合同',
+                        customer: '林静',
+                        employee: '李四'
+                    }
+                ],
+                unallocated: 200.00
+            },
+            transaction3: {
+                payer: '客户C',
+                amount: 1200.00,
+                date: '2025-10-10',
+                status: '未分配',
+                statusColor: 'red',
+                allocations: [],
+                unallocated: 1200.00
+            }
+        };
+
+        const transactionList = document.getElementById('transaction-list');
+        const allocationDetails = document.getElementById('allocation-details');
+
+        function renderTransactionList() {
+            let html = '';
+            Object.keys(dummyData).forEach(key => {
+                const t = dummyData[key];
+                const statusColors = {
+                    green: 'bg-green-100 text-green-800',
+                    yellow: 'bg-yellow-100 text-yellow-800',
+                    red: 'bg-red-100 text-red-800'
+                };
+                html += `
+                    <div id="${key}" class="transaction-item p-4 cursor-pointer hover:bg-gray-100">
+                        <div class="flex justify-between items-center">
+                            <p class="font-semibold text-gray-900">${t.payer}</p>
+                            <p class="font-bold text-lg">¥${t.amount.toFixed(2)}</p>
+                        </div>
+                        <div class="flex justify-between items-center mt-1">
+                            <p class="text-sm text-gray-500">${t.date}</p>
+                            <span class="text-xs font-medium px-2 py-0.5 rounded-full ${statusColors[t.statusColor]}">${t.status}</span>
+                        </div>
+                    </div>
+                `;
+            });
+            transactionList.innerHTML = html;
+        }
+
+        function renderAllocationDetails(key) {
+            const t = dummyData[key];
+            let allocationsHtml = '';
+
+            if (t.allocations.length > 0) {
+                t.allocations.forEach(a => {
+                    allocationsHtml += `
+                        <div class="p-4 border-b last:border-b-0">
+                            <div class="flex items-center">
+                                <div class="w-1/3">
+                                    <p class="text-sm text-gray-500">分配金额</p>
+                                    <p class="font-bold text-green-600 text-lg">¥${a.amount.toFixed(2)}</p>
+                                </div>
+                                <div class="w-2/3 pl-4 border-l">
+                                    <p class="font-semibold text-gray-900">${a.customer} - ${a.employee}</p>
+                                    <p class="text-sm text-gray-600">${a.contract} / ${a.bill}</p>
+                                    <a href="#" class="text-sm text-blue-600 hover:underline">查看账单详情 <i class="fas fa-external-link-alt text-xs"></i></a>
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                });
+            } else {
+                allocationsHtml = `
+                    <div class="p-8 text-center">
+                        <i class="fas fa-info-circle text-4xl text-gray-300"></i>
+                        <p class="mt-4 text-gray-500">此笔回款尚无分配记录</p>
+                    </div>
+                `;
+            }
+
+            let unallocatedHtml = '';
+            if (t.unallocated) {
+                unallocatedHtml = `
+                    <div class="p-4 bg-orange-50 border-t">
+                         <div class="flex items-center">
+                            <div class="w-1/3">
+                                <p class="text-sm text-gray-500">未分配金额</p>
+                                <p class="font-bold text-orange-600 text-lg">¥${t.unallocated.toFixed(2)}</p>
+                            </div>
+                            <div class="w-2/3 pl-4 border-l">
+                                <p class="font-semibold text-gray-900">待处理</p>
+                                <p class="text-sm text-gray-600">请将此部分金额分配到相应账单</p>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            }
+
+            const html = `
+                <div class="p-4 border-b">
+                    <h2 class="text-xl font-semibold">分配详情: ${t.payer}</h2>
+                    <p class="text-sm text-gray-500">总额: ¥${t.amount.toFixed(2)}</p>
+                </div>
+                <div class="divide-y divide-gray-200">
+                    ${allocationsHtml}
+                </div>
+                ${unallocatedHtml}
+            `;
+            allocationDetails.innerHTML = html;
+        }
+
+        transactionList.addEventListener('click', (e) => {
+            const item = e.target.closest('.transaction-item');
+            if (item) {
+                document.querySelectorAll('.transaction-item').forEach(el => el.classList.remove('selected'));
+                item.classList.add('selected');
+                renderAllocationDetails(item.id);
+            }
+        });
+
+        // Initial render
+        renderTransactionList();
+        // Select and render the first item by default
+        const firstItem = document.querySelector('.transaction-item');
+        if (firstItem) {
+            firstItem.classList.add('selected');
+            renderAllocationDetails(firstItem.id);
+        }
+
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
本次提交对银行流水对账页面进行了多项重要改进，旨在提升用户体验和操作效率。

主要变更包括：

1.  **新增“已处理”页签**：
    - 在页签栏中增加“已处理”分类，专门用于展示已全部分配完毕的流水。
    - 这将“已部分分配”和“已全部分配”的流水清晰地隔离开，让用户能更专注于需要处理的事项。

2.  **增加付款人搜索功能**：
    - 在左侧的待处理流水列表上方增加了一个搜索框。
    - 该搜索在前端实现，利用 `pinyin-pro` 库支持按付款人名称的中文、全拼及拼音首字母进行模糊搜索，实现了即时过滤，响应迅速。
    - 同时优化了界面布局，将搜索框与标题栏整合，减少了垂直空间占用。

3.  **优化“未匹配”工作流**：
    - 修复了在“未匹配”页签下，切换左侧流水会导致右侧已选客户信息丢失的问题。
    - 现在，在“未匹配”页签内切换流水时，已选择的客户信息将被保留，方便用户将多笔流水分配给同一个客户。

4.  **修复别名创建的Bug**：
    - 解决了在“未匹配”流程中，因ID数据类型错误（将UUID字符串误判为数字）导致无法正确查找账单，从而使付款人别名创建静默失败的严重bug。
    - 增强了保存操作的用户反馈，现在会明确提示别名是否创建成功。