### PR TITLE
feat(reconciliation): 实现高级忽略功能并修复多项关联Bugs

### DIFF
--- a/frontend/src/components/ReconciliationPage.jsx
+++ b/frontend/src/components/ReconciliationPage.jsx
@@ -840,12 +840,10 @@ export default function ReconciliationPage() {
                 pending_confirmation: [],
                 manual_allocation: [],
                 unmatched: [],
-                confirmed: [],
-                processed: [],
                 ignored: [],
                 ...originalData,
-                confirmed, // This will overwrite originalData.confirmed
-                processed, // This will overwrite originalData.processed
+                confirmed: confirmed, 
+                processed: processed,
             };
             setCategorizedTxns(newData);
 
@@ -881,7 +879,15 @@ export default function ReconciliationPage() {
                     }
                 });
             }
-            const newData = { ...originalData, confirmed, processed };
+            const newData = {
+                pending_confirmation: [],
+                manual_allocation: [],
+                unmatched: [],
+                ignored: [],
+                ...originalData,
+                confirmed: confirmed, 
+                processed: processed,
+            };
 
             const oldCategory = activeTab;
             const oldList = categorizedTxns[oldCategory] || [];


### PR DESCRIPTION
本次提交为对账页面引入了强大的“永久忽略”和“批量忽略”功能，并修复了在此过程中发现的流水导入、UI更新及API路由相关的多个问题。

- **永久与批量忽略**:
  - **永久忽略**:用户在“忽略”流水时，可勾选“永久忽略”。系统将创建一条规则，在后续导入新流水时，自动忽略匹配该规则（付款人+交易方向）的流水。
  - **批量忽略**: “忽略”操作现在会智能地将当月所有来自同一付款人的待处理流水一并忽略。
  - **撤销逻辑**: “撤销忽略”操作会同步删除对应的“永久忽略”规则。
  - **后端支持**: 为此新增了 `PermanentIgnoreList` 数据表（需要执行数据库迁移），并全面更新了 `ignore`, `unignore`和流水导入服务。

- **优化操作月份重置逻辑**:
  - 当用户在左侧列表切换到新客户时，右侧详情面板的月份选择器会自动重置回主账期，避免了操作上的混淆。

- **修复流水导入404/400错误**:
  - 恢复了被意外删除的 `/api/bank-statement/reconcile` 后端接口，并修正了其对JSON数据格式的处理逻辑，使粘贴导入功能恢复正常。

- **修复“代付”标签丢失问题**:
  - 修复了在“待手动分配”页签和UI刷新后，“代付”标签不显示的回归性bug。

- **修复批量忽略后UI不更新问题**:
  - 解决了执行批量忽略后，前端列表只会移除单条流水的UI不同步问题。现在操作后会完整刷新列表。

- **修复删除回款记录404错误**:
  - 通过在后端增加一个“别名路由”，兼容了前端错误的API地址，使删除功能恢复正常。

- **消除构建警告**:
  - 重构了前端数据对象的构建逻辑，消除了Vite在生产构建时报出的 `Duplicate key` 警告。