### PR TITLE
     fix(billing): 完善替班账单和财务调整逻辑

### DIFF
--- a/backend/services/billing_engine.py
+++ b/backend/services/billing_engine.py
@@ -1727,6 +1727,31 @@ class BillingEngine:
         sub_record.generated_bill_id = bill.id
         sub_record.generated_payroll_id = payroll.id
 
+        # Create or get the adjustment with a placeholder amount
+        adjustment = FinancialAdjustment.query.filter_by(
+            customer_bill_id=bill.id,
+            description="[系统] 替班服务费"
+        ).first()
+        if not adjustment:
+            adjustment = FinancialAdjustment(
+                customer_bill_id=bill.id,
+                adjustment_type=AdjustmentType.COMPANY_PAID_SALARY,
+                amount=0, # Placeholder
+                description="[系统] 替班服务费",
+                date=sub_record.start_date,
+            )
+            db.session.add(adjustment)
+            db.session.flush()
+
+        # First calculation to get the correct payroll total
+        details = self._calculate_substitute_details(sub_record, main_contract, bill, payroll, overrides)
+        bill, payroll = self._calculate_final_amounts(bill, payroll, details)
+
+        # Update the adjustment with the payroll total
+        adjustment.amount = payroll.total_due
+        db.session.flush()
+
+        # Recalculate with the correct adjustment amount
         details = self._calculate_substitute_details(sub_record, main_contract, bill, payroll, overrides)
         bill, payroll = self._calculate_final_amounts(bill, payroll, details)
         current_app.logger.info(

--- a/frontend/src/components/BillingDashboard.jsx
+++ b/frontend/src/components/BillingDashboard.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Box, Button, Typography, Paper, Table, TableBody, TableCell, TableContainer,
-  TableHead, TableRow, TablePagination, IconButton, CircularProgress,
+  TableHead, TableRow, TablePagination, IconButton, CircularProgress,TableFooter,
   TextField, Select, MenuItem, FormControl, InputLabel, Chip, Tooltip, Checkbox,
   Card, CardHeader, CardContent, Grid, Dialog, DialogTitle, DialogContent, DialogActions, Divider, List, ListItem, ListItemText, ListItemIcon, Alert
 } from '@mui/material';
@@ -798,6 +798,9 @@ const BillingDashboard = () => {
         setGeneratedMessage('');
     };
 
+    const customerPayableTotal = contracts.reduce((acc, bill) => new Decimal(acc).plus(new Decimal(bill.customer_payable || 0)).toNumber(), 0);
+    const employeePayoutTotal = contracts.reduce((acc, bill) => new Decimal(acc).plus(new Decimal(bill.employee_payout || 0)).toNumber(), 0);
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={zhCN}>
       <Box>
@@ -1177,6 +1180,24 @@ const BillingDashboard = () => {
                     })
                   )}
                 </TableBody>
+                <TableFooter>
+                  <TableRow sx={{ '& > *': { borderBottom: 'none' } }}>
+                    <TableCell colSpan={8} align="right" sx={{ fontWeight: 'bold', fontSize: '1.1rem' }}>
+                        当页小记:
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 'bold', fontSize: '1.1rem' }}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                            <Typography sx={{ fontWeight: 'bold', color: 'error.main' }}>
+                                ¥{customerPayableTotal.toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            </Typography>
+                            <Typography sx={{ fontWeight: 'bold', color: 'success.main' }}>
+                                ¥{employeePayoutTotal.toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            </Typography>
+                        </Box>
+                    </TableCell>
+                    <TableCell></TableCell>
+                  </TableRow>
+                </TableFooter>
               </Table>
               <TablePagination component="div" count={totalContracts} page={page} onPageChange={(e, newPage) => setPage(newPage)} rowsPerPage={rowsPerPage} onRowsPerPageChange={(e) => { setRowsPerPage(parseInt(e.target.value, 10)); setPage(0); }} labelRowsPerPage="每页行数:" />
             </TableContainer>


### PR DESCRIPTION
     本次提交包含多项针对替班账单和财务调整的修复和功能增强，主要包括：

     1.  **修复替班账单重复生成调整项的问题**：

         -   在 `calculate_for_substitute`
     函数中增加了检查，确保“公司代付工资”的财务调整项在重新计算时不会被重复创建，而是更
     新现有项。

     2.  **修正替班服务费的金额**：

         -
     “公司代付工资”调整项的金额现在会动态更新，使其始终等于替班员工的“应发总额”，确保了客户账单与员工薪酬的精确对应。

     3.  **修正外部替班合同的财务调整计算**：

         -   修复了 `_calculate_external_substitution_details`
     函数中未计算财务调整项的bug，确保增减款项能被正确计入账单。

     4.  **理清“公司代付工资”的计算逻辑**：

         -
     根据最新的需求，明确了“公司代付工资”这一调整项仅影响客户的应收总额，不再计入员工的应发工资中，避免了重复计算。

     feat(frontend): 在账单列表中增加当页小记

     在账单列表的表格底部增加了一个“当页小记”行，用于实时统计当前页面所有账单的“客户应付款总额”和“员工应收款总额”，提高
     了财务
     人员的对账效率。