### PR TITLE
fix(frontend): 修复对账页面财务调整项保存后丢失的问题

### DIFF
--- a/frontend/src/components/ReconciliationPage.jsx
+++ b/frontend/src/components/ReconciliationPage.jsx
@@ -800,6 +800,27 @@ export default function ReconciliationPage() {
             setAlertInfo({ open: true, message: `提交失败: ${err.message}`, severity: 'error' });
         }
     };
+    
+    const handleSaveBillDetails = async (payload) => {
+        setLoadingBillDetails(true); // 开始加载
+        try {
+            const response = await api.post('/billing/batch-update', payload);
+            const newDetails = response.data.latest_details;
+
+            // 用后端返回的最新数据，更新弹窗的 state
+            setSelectedBillDetails(newDetails);
+
+            setAlertInfo({ open: true, message: response.data.message || "保存成功！", severity:'success' });
+
+            // 同时刷新对账页面左侧的流水列表，以反映可能的账单状态变化
+            softRefresh();
+
+        } catch (error) {
+            setAlertInfo({ open: true, message: `保存失败: ${error.response?.data?.error || error.message}`, severity: 'error' });
+        } finally {
+            setLoadingBillDetails(false); // 结束加载
+        }
+    };
 
     const handleTabChange = (event, newValue) => {
         setOverrideCustomerName(null);
@@ -1397,7 +1418,7 @@ export default function ReconciliationPage() {
                     billingMonth={selectedBillContext?.billingMonth}
                     billingDetails={selectedBillDetails}
                     loading={loadingBillDetails}
-                    onSave={softRefresh}
+                    onSave={handleSaveBillDetails}
                     onNavigateToBill={(billId) => {
                         console.log("Navigate to bill ID:", billId);
                     }}


### PR DESCRIPTION
- 在 `ReconciliationPage` 中，为 `FinancialManagementModal` 提供了正确的 `onSave` 回调`handleSaveBillDetails`。
- `handleSaveBillDetails` 函数负责将 `FinancialManagementModal`中修改后的数据（包括调整项、加班天数、实际劳务天数、发票等）发送到后端 API (`/billing/batch-update`) 进行保存。
- 保存成功后，`handleSaveBillDetails` 会刷新对账页面左侧的流水列表，确保状态同步。