### PR TITLE
feat(frontend): 在对账页面为只有合同的客户添加切换功能

### DIFF
--- a/frontend/src/components/ReconciliationPage.jsx
+++ b/frontend/src/components/ReconciliationPage.jsx
@@ -444,7 +444,10 @@ const TransactionDetailsPanel = ({
                     !groupedBills[info.customer_name] && (
                         <Paper key={info.customer_name} sx={{ p: 2, mb: 3 }} variant="outlined">
                             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent:'space-between', mb: 1 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                 <Typography variant="h6">客户: {info.customer_name}</Typography>
+                                <Button size="small" startIcon={<SwitchAccountIcon />} onClick={() =>setIsSwitchingCustomer(true)}>切换客户</Button>
+                                </Box>
                             </Box>
                             <Box sx={{ p: 3, textAlign: 'center', color: 'text.secondary' }}>
                                 <Typography>在 {accountingPeriod.year}年{accountingPeriod.month}月未找到该客户的账单。</Typography>


### PR DESCRIPTION
在对账页面，当一个付款人只有合同而没有对应月份的账单时，之前缺少“切换客户”的按钮。

本次修改为这种情况增加了“切换客户”按钮，确保了在所有客户匹配场景下，用户都有一致的操作体验，可以灵活地为流水重新指定客户。