### PR TITLE
  fix(billing): 完善“公司代付工资”调整项的完整处理逻辑

### DIFF
--- a/backend/api/billing_api.py
+++ b/backend/api/billing_api.py
@@ -4196,7 +4196,7 @@ def add_payout_record(payroll_id):
                 )
                 db.session.add(company_paid_adj)
                 _log_activity(customer_bill, payroll, "系统自动创建客户增款", details={
-                    "reason": "公司代付员工工资",
+                    "reason": "公司代付工资",
                     "amount": str(new_payout.amount),
                     "description": description
                 })


### PR DESCRIPTION
  本次提交对“公司代付工资” (COMPANY_PAID_SALARY) 这一财务调整项的创建、更新、关联和历史数据回溯逻辑进
  行了全面的修复和统一，解决了多个场景下的逻辑冲突和数据不一致问题。

   1. 修复：调整项的创建与更新冲突
       - 问题: 系统会自动创建“公司代付工资”项，即使用户手动删除后也会再次出现。同时，在某些情况下（如修
         改劳务天数），该调整项的金额又不会自动更新。
       - 解决方案 (计费引擎): 重构了 billing_engine.py 的核心逻辑。
           - 正式合同: 引擎现在只负责更新已存在的、由系统创建的调整项金额，但绝不再自动创建新的条目，解
             决了“系统与用户操作打架”的问题。
           - 试工合同: 为试工合同的结算逻辑 (process_trial_termination)
             引入了同样的“更新而非创建”机制，修复了修改加班天数后金额不变的bug。
           - “最终月”判断: 优化了判断逻辑，使其能正确地将“已终止”的合同的最后一个账单视作最终月，确保更
             新逻辑能被触发。

   2. 实现：试工合同“代付工资”计算新规则
       - 需求: “公司代付工资”的金额，应为“应发总额”和“员工月薪”两者中的较小值。
       - 实现: 在 process_trial_termination 函数中，实现了此新规则，确保了试工合同结算的财务准确性。

   3. 修复：手动添加时关联错误
       - 问题: 用户手动添加“公司代付工资”项时，该条目被错误地关联到了员工工资单 (employee_payroll_id)
         而不是客户账单 (customer_bill_id)。
       - 解决方案 (API): 在 billing_api.py 中，已将 COMPANY_PAID_SALARY
         类型正确归类为客户账单侧的调整，确保其在创建时能被正确关联。

   4. 修复与新增：历史数据处理工具
       - 问题: add-salary-adjustments 命令创建的调整项描述不一致；同时历史数据中存在大量错误关联。
       - 解决方案 (管理工具):
           - 在 management_commands.py 中，统一了 add-salary-adjustments 命令创建的调整项描述字符串。
           - 新增了 flask fix-salary-adj-links
             命令，用于扫描并修复历史数据，将错误关联到工资单的调整项重新关联到正确的客户账单上。

  通过以上修改，现在“公司代付工资”调整项的行为在手动操作、自动更新和历史数据处理上保持了一致和可预测
  性。