### PR TITLE
  fix(billing): 确保向账单详情弹窗传递合同状态

### DIFF
--- a/backend/api/billing_api.py
+++ b/backend/api/billing_api.py
@@ -5165,6 +5165,7 @@ def get_bills_by_customer():
             all_bills_results.append({
                 "id": str(bill.id),
                 "contract_id": str(bill.contract.id),
+                "contract_status": bill.contract.status,
                 "customer_name": bill.contract.customer_name,
                 "employee_name": employee_name,
                 "is_substitute_bill": bill.is_substitute_bill,

--- a/frontend/src/components/FinancialManagementModal.jsx
+++ b/frontend/src/components/FinancialManagementModal.jsx
@@ -214,6 +214,7 @@ const getTooltipContent = (fieldName, billingDetails, isCustomer, adjustment = n
 
 // --- 主组件 ---
 const FinancialManagementModal = ({ open, onClose, contract, billingMonth, billingDetails: initialBillingDetails, loading, onSave, onNavigateToBill }) => {
+    // console.log("[DEBUG] FinancialManagementModal received contract prop:", contract);
     const [latestSavedData, setLatestSavedData] = useState(null);
     const navigate = useNavigate();
     const [isEditMode, setIsEditMode] = useState(false);


### PR DESCRIPTION
  修复了从“银行流水对账”页面打开账单详情弹窗时，“转移此账单余额”按钮不显示的问题。

  该按钮的显示依赖于合同状态（contract.status）是否为 terminated 或
  finished。此前，从对账页面打开弹窗时，传递给 FinancialManagementModal 组件的 contract prop
  是一个不包含 status 字段的最小化上下文对象，导致按钮的显示条件判断失败。

  本次修复包含两部分：
   1. 后端: 修改 /api/billing/bills-by-customer 接口，使其在返回的每个账单对象中，都包含其关联合同的
      contract_status 字段。
   2. 前端: 修改 ReconciliationPage.jsx 中的 handleOpenBillModal 函数，在构建传递给弹窗的 contract
      上下文对象时，将 contract_status 也一并传入。

  这确保了 FinancialManagementModal
  无论从何处打开，都能接收到完整的上下文信息，从而正确渲染所有依赖于合同状态的UI元素。