### PR TITLE
feat: 弃用 user_id 并增强员工同步与展示

### DIFF
--- a/frontend/src/components/StaffDetailPage.jsx
+++ b/frontend/src/components/StaffDetailPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Box, Card, CardContent, CardHeader, CircularProgress, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Button } from '@mui/material';
+import { Box, Card, CardContent, CardHeader, CircularProgress, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Button, Link } from '@mui/material';
 import api from '../api';
 import PageHeader from './PageHeader';
 
@@ -44,6 +44,16 @@ function StaffDetailPage() {
     return new Date(dateString).toLocaleDateString();
   };
 
+  const getContractTypeLabel = (type) => {
+    switch (type) {
+      case 'nanny': return '育儿嫂合同';
+      case 'maternity_nurse': return '月嫂合同';
+      case 'nanny_trial': return '育儿嫂试工合同';
+      case 'external_substitution': return '外部替班合同';
+      default: return type || '未知类型';
+    }
+  };
+
   const SalaryChangeArrow = ({ previous, current }) => {
     const prev = parseFloat(previous);
     const curr = parseFloat(current);
@@ -52,6 +62,12 @@ function StaffDetailPage() {
     if (curr > prev) return <span style={{ color: 'green' }}>↑</span>;
     if (curr < prev) return <span style={{ color: 'red' }}>↓</span>;
     return null;
+  };
+
+  const handleCustomerClick = (contractId) => {
+    if (contractId) {
+      window.open(`/contract/detail/${contractId}`, '_blank');
+    }
   };
 
   return (
@@ -85,7 +101,7 @@ function StaffDetailPage() {
                   <TableCell>原月薪</TableCell>
                   <TableCell>变更后月薪</TableCell>
                   <TableCell>变化</TableCell>
-                  <TableCell>生效日期</TableCell>
+                  <TableCell>合同类型</TableCell>
                   <TableCell>合同备注</TableCell>
                 </TableRow>
               </TableHead>
@@ -93,13 +109,21 @@ function StaffDetailPage() {
                 {employee.salary_history && employee.salary_history.length > 0 ? (
                   employee.salary_history.map(record => (
                     <TableRow key={record.id}>
-                      <TableCell>{record.customer_name || 'N/A'}</TableCell>
+                      <TableCell>
+                        {record.contract_id ? (
+                          <Link component="button" variant="body2" onClick={() => handleCustomerClick(record.contract_id)}>
+                            {record.customer_name || 'N/A'}
+                          </Link>
+                        ) : (
+                          record.customer_name || 'N/A'
+                        )}
+                      </TableCell>
                       <TableCell>{formatDate(record.contract_start_date)} - {formatDate(record.contract_end_date)}</TableCell>
                       <TableCell>{record.customer_address || 'N/A'}</TableCell>
                       <TableCell>{record.previous_salary || 'N/A'}</TableCell>
                       <TableCell>{record.new_salary}</TableCell>
                       <TableCell><SalaryChangeArrow previous={record.previous_salary} current={record.new_salary} /></TableCell>
-                      <TableCell>{formatDate(record.effective_date)}</TableCell>
+                      <TableCell>{getContractTypeLabel(record.contract_type)}</TableCell>
                       <TableCell>{record.contract_notes || 'N/A'}</TableCell>
                     </TableRow>
                   ))


### PR DESCRIPTION
本次提交完成了一项重要的重构，旨在统一员工关联模型，并修复了相关的前后端功能。

主要变更包括：
- **后端重构:**
    - 在所有后端 API 和服务中，弃用 `BaseContract.user_id` 和 `contract.user` 关系。
    - 统一使用 `service_personnel_id` 作为合同与服务人员的唯一关联，简化了数据模型。
- **员工同步功能增强 (`user_sync.py` & `management_commands.py`):**
    - 扩展了 `/api/user_sync` 接口，使其在同步 `user` 表的同时，能够创建或更新 `service_personnel` 表。
    - 增加了基于身份证、手机号和姓名的排重逻辑，防止创建重复的服务人员记录。
    - 修复了同步逻辑中的多个错误，包括 `NotNullViolation`、角色判断错误，并确保 `address`, `name_pinyin`, `is_active` 等字段能被正确同步和更新。
    - 新增 `flask sync-users` 命令，使其能够检查所有学生角色的用户，并修复或创建关联的 `service_personnel` 记录，保证了命令的幂等性。
- **用户状态同步 (`app.py`):**
    - 修改了 `PUT /api/users/<id>` 接口，当更新用户 `status` 时，会自动同步更新关联的 `service_personnel` 表中的 `is_active` 状态。
- **前端功能优化 (`StaffDetailPage.jsx`):**
    - 在员工薪资历史表格中，将客户名称改为可点击的链接，方便在新标签页中快速查看关联合同详情。
    - 将表格中的“生效日期”列改为“合同类型”，并增加了中文转换，使信息更清晰。

此次重构统一了数据模型，修复了数据同步中的多个关键问题，并提升了前端页面的用户体验。