### PR TITLE
fix(nanny-trial): 修正试工合同 employee_level 存储并增强手动创建UI

### DIFF
--- a/backend/api/contract_api.py
+++ b/backend/api/contract_api.py
@@ -681,6 +681,13 @@ def create_formal_contract():
 
         # --- Model Selection and Creation ---
         contract_type = data["contract_type"]
+        # --- 核心修复：对试工合同，强制使用 daily_rate 作为 employee_level ---
+        if contract_type == "nanny_trial":
+            daily_rate_from_request = data.get("daily_rate")
+            if daily_rate_from_request:
+                common_attributes["employee_level"] = to_decimal(daily_rate_from_request)
+                current_app.logger.info(f"[CreateFormalContract] 试工合同，使用 daily_rate ( {daily_rate_from_request}) 覆盖 employee_level。")
+        # --- 修复结束 ---
         ContractModel = None
 
         # --- Model Selection and Creation ---


### PR DESCRIPTION
本次提交修复了手动创建“育儿嫂试工合同”时的一个关键bug，并增强了用户界面以提供更清晰的信息。

- **后端 (`backend/api/contract_api.py`):**
  - **修复:** 在 `create_formal_contract` 接口中，修正了一个bug，该bug导致“育儿嫂试工合同”的 `employee_level` 被错误地存储为月薪。现在，逻辑明确使用请求 payload 中的 `daily_rate` 来设置试工合同的 `employee_level`，确保了账单计算的数据完整性。

- **前端 (`frontend/src/components/CreateFormalContractModal.jsx`):**
  - **功能:** 实现了为“育儿嫂试工合同”自动生成详细计算说明备注的功能。该备注显示在 `attachment_content` 字段中。
  - **逻辑:** 备注内容基于账单引擎中的“日薪转临时月薪再取整”算法，解释了员工劳务费和管理费的计算方法。
  - **规则:** 备注动态反映了“介绍费”和“管理费率”的互斥性。如果存在介绍费，备注会明确说明不收取管理费。

这些修改确保了试工合同数据的正确存储，并为用户在手动创建合同时提供了清晰、自动化的薪酬计算说明