### PR TITLE
feat(salary-history): 实现薪酬历史回填命令并修复UI显示问题

### DIFF
--- a/backend/api/staff_api.py
+++ b/backend/api/staff_api.py
@@ -119,7 +119,8 @@ def get_employee_details(employee_id):
             "contract_end_date": contract.end_date.isoformat() if contract and contract.end_date else None,
             "customer_address": customer.address if customer else None,
             "contract_notes": contract.notes if contract else None,
-            "contract_id": str(contract.id) if contract else None
+            "contract_id": str(contract.id) if contract else None,
+            "contract_type": contract.type if contract else None 
         })
 
     # 3. 返回给前端时，按日期降序，方便展示

--- a/frontend/src/components/CreateFormalContractModal.jsx
+++ b/frontend/src/components/CreateFormalContractModal.jsx
@@ -30,7 +30,7 @@ const initialState = {
     deposit_rate: 0.25,
     daily_rate: '',
     management_fee_rate: 0.20,
-    service_content: [],
+    service_content: "",
     service_type: '',
     is_auto_renew: false,
     attachment_content: '',


### PR DESCRIPTION
本次提交引入了一个新的命令行工具用于管理员工薪酬历史，并解决了多个前端和后端数据展示不一致的问 题。

- **前端 (`frontend/src/components/CreateFormalContractModal.jsx`):**
  - **修复:** 解决了MUI `Select` 组件的一个警告，将 `service_content` 的初始状态从空数组 (`[]`) 更改为空字符串 (`''`)，使其与组件期望的值类型保持一致。

- **后端 (`backend/management_commands.py`):**
  - **功能:** 添加了 `flask backfill-salary-history` 命令，用于为现有合同创建或更新 `EmployeeSalaryHistory` 记录。
    - 该命令会遍历所有具有有效 `employee_level` 的非试工合同。
    - 如果薪酬历史记录不存在，则创建新记录；如果 `base_salary` 与合同的 `employee_level` 不同，则更新现有记录。
    - 包含 `--dry-run` 选项以确保安全执行。
  - **修复:** 解决了 `sqlalchemy.exc.ProgrammingError`，通过在查询过滤器中将 `BaseContract.employee_level` 显式转换为 `Numeric` 类型，从而正确处理字符串存储值的数字比较。
  - **修复:** 解决了 `backfill-salary-history` 命令中的 `ValueError`，确保在调用 `contract_service.update_employee_salary_history` 时，`contract.service_personnel_id` 和 `contract.id` 作为 `str` 类型传递，以匹配服务函数的参数类型。

- **后端 (`backend/api/staff_api.py`):**
  - **修复:** 修正了 `get_employee_details` 接口，使其在序列化 `salary_history` 记录时包含 `contract_type` 字段。这解决了前端 `StaffDetailPage` 上“未知”合同类型显示的问题。

这些更改增强了薪酬历史管理的健壮性，提高了数据完整性，并为应用程序提供了更准确和用户友好的体验 。