### PR TITLE
frontend/src/components/DynamicFormPage.jsx:

### DIFF
--- a/frontend/src/components/DynamicFormPage.jsx
+++ b/frontend/src/components/DynamicFormPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom'; // Import createPortal directly
+// import { createPortal } from 'react-dom'; // Removed to avoid production build issues
 import { useParams, useLocation } from 'react-router-dom'; // 导入 useLocation
 import { Model } from 'survey-core';
 import { Survey } from 'survey-react-ui';
@@ -17,7 +17,8 @@ import {
     Box,
     Button,
     Typography,
-    IconButton
+    IconButton,
+    Portal // Import Portal from MUI
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { formatAddress } from '../utils/formatUtils';
@@ -57,8 +58,8 @@ const HeaderButtonsPortal = ({ currentMode, toggleMode, formToken, dataId, api }
 
     if (!container) return null;
 
-    return createPortal(
-        <>
+    return (
+        <Portal container={container}>
             {formToken === 'N0Il9H' && (
                 <Button
                     variant="contained"
@@ -98,8 +99,7 @@ const HeaderButtonsPortal = ({ currentMode, toggleMode, formToken, dataId, api }
             >
                 切换到 {currentMode === 'admin_view' ? '编辑模式' : '查看模式'}
             </Button>
-        </>,
-        container
+        </Portal>
     );
 };
 


### PR DESCRIPTION
UI 优化: 使用 React Portals 将“切换模式”和“创建员工”按钮移动到 SurveyJS 头部，移除了冗余的页面标题，使界面更整洁。
修复生产环境错误: 使用 Material UI 的 Portal 组件替代 ReactDOM.createPortal，解决了生产构建中因 react-dom 默认导出问题导致的 TypeError。
移动端适配: 添加 CSS 确保头部按钮在移动设备上正确显示。
分数显示: 重构 onComplete 以使用自定义 ScoreDisplay 组件，确保提交后可靠地展示分数。
提交逻辑: 修复数据提交逻辑，确保后端接收正确的数据结构。