### PR TITLE
修复考勤管理页面统计逻辑错误

### DIFF
--- a/frontend/src/components/attendance/AttendanceManagementPage.jsx
+++ b/frontend/src/components/attendance/AttendanceManagementPage.jsx
@@ -92,7 +92,7 @@ const AttendanceManagementPage = () => {
     const stats = {
         total: employees.length,
         pending: employees.filter(e => e.form_status === 'confirmed').length,
-        completed: employees.filter(e => e.form_status === 'signed').length,
+        completed: employees.filter(e => e.form_status === 'customer_signed').length,
         notStarted: employees.filter(e => ['not_created', 'draft'].includes(e.form_status)).length
     };
 


### PR DESCRIPTION
问题：客户已签署的考勤表未计入已完成统计
原因：统计代码使用了错误的状态值'signed'，实际应为'customer_signed'
影响：导致已完成数量显示不准确

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>