### PR TITLE
fix: 修复续签合同考勤日期合并问题

### DIFF
--- a/frontend/src/components/attendance/AttendanceRouter.jsx
+++ b/frontend/src/components/attendance/AttendanceRouter.jsx
@@ -34,7 +34,11 @@ const AttendanceRouter = () => {
                     navigate(`/attendance-fill/${data.data.form_token}`, { replace: true });
                 } else if (data.redirect_type === 'multiple') {
                     // 多个考勤表，显示选择页面
-                    setAttendanceData(data.data);
+                    // employee_name 在顶层，forms 在 data.data 里
+                    setAttendanceData({
+                        forms: data.data.forms,
+                        employee_name: data.employee_name
+                    });
                     setLoading(false);
                 } else {
                     // 没有考勤表


### PR DESCRIPTION
- 修改合同合并优先级：优先按customer_name合并（因为续签合同的customer_id可能不一致）
- 修复by-token API：通过form_id或employee_access_token查找时调用find_consecutive_contracts获取合并日期
- 确保同一客户的续签合同能正确合并考勤日期范围