### PR TITLE
修复考勤自动补齐与月签 pending 合同处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ backend/static/signatures/
 backend/scripts/
 scripts/*
 !scripts/cleanup_renewed_nanny_contract_history.py
+!scripts/normalize_attendance_auto_overtime.py
 commit_message.txt
 
 design_proposals/

--- a/backend/api/attendance_form_api.py
+++ b/backend/api/attendance_form_api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request, current_app, render_template, make_response
 from backend.models import db, AttendanceForm, BaseContract, ServicePersonnel, AttendanceRecord, NannyContract
-from backend.services.attendance_sync_service import sync_attendance_to_record
+from backend.services.attendance_sync_service import sync_attendance_to_record, normalize_auto_overtime_form_data
 from backend.services.billing_engine import BillingEngine
 import uuid
 from datetime import datetime, date, timedelta
@@ -124,7 +124,7 @@ def filter_contracts_for_cycle(employee_id, cycle_start, cycle_end):
     统一的合同过滤函数：查找指定周期内有效的合同
     
     过滤规则：
-    1. 月签合同（is_monthly_auto_renew=True 且 status='active'）：不检查 end_date
+    1. 月签合同（is_monthly_auto_renew=True 且 status 为 active/pending）：不检查 end_date
     2. 已终止合同：使用 termination_date 作为实际结束日期
     3. 普通合同：检查 end_date >= cycle_start
     4. 月嫂合同：优先使用 actual_onboarding_date 作为开始日期
@@ -151,7 +151,7 @@ def filter_contracts_for_cycle(employee_id, cycle_start, cycle_end):
         monthly_flag = getattr(c, 'is_monthly_auto_renew', None)
         current_app.logger.info(f"[DEBUG]   - 合同 {c.id}: type={c.type}, status={c.status}, start={c.start_date}, end={c.end_date}, is_monthly_auto_renew={monthly_flag}")
     
-    # 过滤：只保留 end_date >= cycle_start 的合同，或者月签合同（active 状态）
+    # 过滤：只保留 end_date >= cycle_start 的合同，或者月签合同（active/pending 状态）
     contracts = []
     for c in all_contracts:
         # 获取实际开始日期（月嫂合同优先使用 actual_onboarding_date）
@@ -168,7 +168,7 @@ def filter_contracts_for_cycle(employee_id, cycle_start, cycle_end):
         
         # 检查是否是月签合同（育儿嫂合同）
         is_monthly = False
-        if c.type == 'nanny' and c.status == 'active':
+        if c.type == 'nanny' and c.status in ('active', 'pending'):
             # 使用 getattr 获取 is_monthly_auto_renew 属性，默认为 False
             # 注意：getattr 可能返回 None，需要显式转换为 bool
             monthly_flag = getattr(c, 'is_monthly_auto_renew', None)
@@ -184,7 +184,7 @@ def filter_contracts_for_cycle(employee_id, cycle_start, cycle_end):
         else:
             actual_end = end_date
         
-        # 月签合同（active）不检查 end_date
+        # 月签合同（active/pending）不检查 end_date
         if is_monthly:
             contracts.append(c)
             current_app.logger.info(f"  - 月签合同 {c.id}: {actual_start} 到 {c.end_date}, 客户={c.customer_name}, status={c.status}")
@@ -457,9 +457,9 @@ def get_attendance_form_by_token(employee_token):
                 actual_start = target_contract.start_date.date() if isinstance(target_contract.start_date, datetime) else target_contract.start_date
             
             # 获取合同的实际结束日期
-            is_monthly = getattr(target_contract, 'is_monthly_auto_renew', False) and target_contract.status == 'active'
+            is_monthly = getattr(target_contract, 'is_monthly_auto_renew', False) and target_contract.status in ('active', 'pending')
             if is_monthly:
-                # 月签合同（active）没有结束日期限制
+                # 月签合同（active/pending）没有结束日期限制
                 actual_end = None
             elif target_contract.status == 'terminated' and target_contract.termination_date:
                 actual_end = target_contract.termination_date.date() if isinstance(target_contract.termination_date, datetime) else target_contract.termination_date
@@ -752,6 +752,10 @@ def update_attendance_form(employee_token):
         
         if form_data:
             form.form_data = form_data
+            normalized_form_data, normalized = normalize_auto_overtime_form_data(form)
+            if normalized:
+                form.form_data = normalized_form_data
+                form_data = normalized_form_data
             
         # 如果是提交确认
         action = data.get('action')
@@ -1300,16 +1304,16 @@ def get_monthly_attendance_list():
         # 查找所有活跃、已完成或已终止的合同，且合同有效期与指定月份有交集
         # 注意：
         # 1. 对于已终止合同，使用 termination_date 作为结束时间
-        # 2. 对于月签合同（is_monthly_auto_renew=True），如果状态是 active，则忽略 end_date 限制
+        # 2. 对于月签合同（is_monthly_auto_renew=True），如果状态是 active 或 pending，则忽略 end_date 限制
         contracts = BaseContract.query.filter(
             BaseContract.status.in_(['active', 'pending', 'terminated', 'finished', 'completed']),
             BaseContract.start_date <= month_end,
             or_(
-                # 情况1: 月签合同且状态为 active，不检查 end_date（会自动续约）
+                # 情况1: 月签合同且状态为 active/pending，不检查 end_date（会自动续约）
                 and_(
                     BaseContract.type == 'nanny',
                     NannyContract.is_monthly_auto_renew == True,
-                    BaseContract.status == 'active'
+                    BaseContract.status.in_(['active', 'pending'])
                 ),
                 # 情况2: 没有终止日期，使用 end_date 判断
                 and_(BaseContract.termination_date.is_(None), BaseContract.end_date >= month_start),

--- a/backend/services/attendance_sync_service.py
+++ b/backend/services/attendance_sync_service.py
@@ -1,9 +1,147 @@
 from backend.models import db, AttendanceForm, AttendanceRecord, BaseContract
 from backend.services.billing_engine import BillingEngine
 from datetime import datetime, date
+from copy import deepcopy
 import calendar
 from decimal import Decimal, ROUND_HALF_UP
 from flask import current_app
+
+
+def _parse_date(value):
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return datetime.fromisoformat(str(value)).date()
+
+
+def _record_hours(record):
+    hours = record.get("hours", 0) or 0
+    minutes = record.get("minutes", 0) or 0
+    return Decimal(str(hours)) + Decimal(str(minutes)) / Decimal(60)
+
+
+def _is_full_day_overtime(record):
+    return (
+        record.get("type") == "overtime"
+        and (record.get("daysOffset") or 0) == 0
+        and record.get("startTime") == "00:00"
+        and record.get("endTime") == "24:00"
+        and _record_hours(record) >= Decimal("23.99")
+    )
+
+
+def _is_statutory_holiday(target_date):
+    # 目前自动补齐只需要避免把 5/1、5/2 这类法定假日加班误识别为月末补齐。
+    fixed_holidays = {(1, 1), (5, 1), (5, 2), (5, 3), (10, 1), (10, 2), (10, 3)}
+    return (target_date.month, target_date.day) in fixed_holidays
+
+
+def _calculate_records_days(records):
+    total_days = Decimal(0)
+    for record in records or []:
+        total_days += _record_hours(record) / Decimal(24)
+    return total_days
+
+
+def normalize_auto_overtime_form_data(form):
+    """
+    规范化自动补齐加班数据，避免历史表把月末补齐块按整天入库导致工资多算。
+    返回 (normalized_data, changed)。
+    """
+    data = deepcopy(form.form_data or {})
+    overtime_records = data.get("overtime_records") or []
+    if not overtime_records:
+        return data, False
+
+    cycle_start = _parse_date(form.cycle_start_date)
+    cycle_end = _parse_date(form.cycle_end_date)
+    month_days = [
+        date.fromordinal(day_ordinal)
+        for day_ordinal in range(cycle_start.toordinal(), cycle_end.toordinal() + 1)
+    ]
+
+    overtime_by_date = {}
+    for record in overtime_records:
+        record_date = record.get("date")
+        if record_date and _is_full_day_overtime(record):
+            overtime_by_date[record_date] = record
+
+    legacy_auto_dates = []
+    for day in reversed(month_days):
+        day_str = day.isoformat()
+        if day_str in overtime_by_date and not _is_statutory_holiday(day):
+            legacy_auto_dates.append(day_str)
+        else:
+            break
+
+    existing_auto_records = [r for r in overtime_records if r.get("is_auto")]
+    if not legacy_auto_dates and not existing_auto_records:
+        return data, False
+
+    rest_days = _calculate_records_days(data.get("rest_records", []))
+    leave_days = _calculate_records_days(data.get("leave_records", []))
+    total_leave_days = rest_days + leave_days
+
+    manual_normal_overtime_days = Decimal(0)
+    legacy_auto_date_set = set(legacy_auto_dates)
+    for record in overtime_records:
+        if record.get("is_auto") or record.get("date") in legacy_auto_date_set:
+            continue
+        record_date = _parse_date(record.get("date"))
+        if not _is_statutory_holiday(record_date):
+            manual_normal_overtime_days += _record_hours(record) / Decimal(24)
+
+    valid_days_count = Decimal(len(month_days))
+    total_work_days_before_cap = valid_days_count - total_leave_days
+    auto_overtime_days = total_work_days_before_cap - Decimal("26") - manual_normal_overtime_days
+    if auto_overtime_days <= 0:
+        auto_overtime_days = Decimal(0)
+
+    # 对没有 is_auto 标记的历史数据，只做“降噪/等量规范化”，绝不自动增加加班天数。
+    # 否则可能把真实手填的月末加班误判为自动补齐。
+    legacy_auto_days = Decimal(len(legacy_auto_dates))
+    if legacy_auto_dates and not existing_auto_records and auto_overtime_days > legacy_auto_days:
+        return data, False
+
+    auto_minutes = int((auto_overtime_days * Decimal(24) * Decimal(60)).to_integral_value(rounding=ROUND_HALF_UP))
+    auto_hours = auto_minutes // 60
+    auto_remaining_minutes = auto_minutes % 60
+
+    normalized_overtime = [
+        r for r in overtime_records
+        if not r.get("is_auto") and r.get("date") not in legacy_auto_date_set
+    ]
+
+    if auto_minutes > 0:
+        auto_dates = sorted(legacy_auto_dates)
+        if not auto_dates and existing_auto_records:
+            first_auto = min(existing_auto_records, key=lambda r: r.get("date", "9999-99-99"))
+            first_date = _parse_date(first_auto.get("date"))
+            days_offset = int(existing_auto_records[0].get("daysOffset") or 0)
+            auto_dates = [
+                date.fromordinal(day_ordinal).isoformat()
+                for day_ordinal in range(first_date.toordinal(), first_date.toordinal() + days_offset + 1)
+            ]
+        if auto_dates:
+            max_minutes = len(auto_dates) * 24 * 60
+            missing_minutes_on_first_day = max(0, max_minutes - auto_minutes)
+            start_hour = missing_minutes_on_first_day // 60
+            start_minute = missing_minutes_on_first_day % 60
+            normalized_overtime.append({
+                "date": auto_dates[0],
+                "type": "overtime",
+                "startTime": f"{start_hour:02d}:{start_minute:02d}",
+                "endTime": "24:00",
+                "hours": auto_hours,
+                "minutes": auto_remaining_minutes,
+                "daysOffset": len(auto_dates) - 1,
+                "is_auto": True
+            })
+
+    normalized_overtime.sort(key=lambda r: r.get("date", ""))
+    data["overtime_records"] = normalized_overtime
+    return data, data != (form.form_data or {})
 
 def get_onboarding_time_for_contract(employee_id, contract_id):
     """
@@ -120,7 +258,10 @@ def sync_attendance_to_record(attendance_form_id):
         current_app.logger.error(f"[ATTENDANCE_SYNC] AttendanceForm {attendance_form_id} not found")
         raise ValueError(f"AttendanceForm {attendance_form_id} not found")
         
-    data = form.form_data
+    data, normalized = normalize_auto_overtime_form_data(form)
+    if normalized:
+        form.form_data = data
+        current_app.logger.info(f"[ATTENDANCE_SYNC] 已规范化自动补齐加班数据: form_id={form.id}")
     current_app.logger.debug(f"[ATTENDANCE_SYNC] 表单数据: {data}")
     
     # 1. 辅助函数: 将小时分钟转换为天数 (8小时制? 还是24小时? 通常考勤按工作日计算)

--- a/frontend/src/components/attendance/AttendanceFillPage.jsx
+++ b/frontend/src/components/attendance/AttendanceFillPage.jsx
@@ -1503,21 +1503,22 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             // 计算该片段可分配的时长
             const maxHoursForGroup = daysCount * 24;
             const hoursForGroup = Math.min(maxHoursForGroup, remainingHours);
+            const totalMinutesForGroup = Math.round(hoursForGroup * 60);
 
             if (hoursForGroup <= 0.01) return; // 忽略忽略不计的时长
 
-            // 构造跨天记录
-            const startTime = '00:00';
+            // 构造跨天记录：从月末往前补齐，零头放在该片段最早一天，最后一天保持补满
+            let startTime = '00:00';
             let endTime = '24:00';
 
-            // 如果该片段的时长不是整天倍数，调整 endTime
+            // 如果该片段的时长不是整天倍数，调整 startTime，而不是 endTime
             if (Math.abs(hoursForGroup - maxHoursForGroup) > 0.01) {
-                // 计算最后一天的截止时间
-                const lastDayDuration = hoursForGroup % 24 || 24;
-                if (Math.abs(lastDayDuration - 24) > 0.01) {
-                    const h = Math.floor(lastDayDuration);
-                    const m = Math.round((lastDayDuration % 1) * 60);
-                    endTime = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+                const missingMinutesOnFirstDay = maxHoursForGroup * 60 - totalMinutesForGroup;
+                if (missingMinutesOnFirstDay > 0) {
+                    const startMinutes = missingMinutesOnFirstDay;
+                    const h = Math.floor(startMinutes / 60);
+                    const m = startMinutes % 60;
+                    startTime = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
                 }
             }
 
@@ -1527,8 +1528,8 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                 type: 'overtime',
                 startTime: startTime,
                 endTime: endTime,
-                hours: Math.floor(hoursForGroup),
-                minutes: Math.round((hoursForGroup % 1) * 60),
+                hours: Math.floor(totalMinutesForGroup / 60),
+                minutes: totalMinutesForGroup % 60,
                 daysOffset: daysCount - 1,
                 is_auto: true // 标记为系统自动补齐的加班，便于下一次计算时实施垃圾回收
             });
@@ -1677,6 +1678,9 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     let totalWorkDays = 0; // 出勤天数
     let totalLeaveDays = 0; // 请假或休假天数（休息、请假，不含带薪休假）
     let totalOvertimeDays = 0; // 加班天数（单独统计）
+    let totalManualOvertimeDays = 0; // 用户手动填写的加班天数
+    let manualNormalOvertimeDays = 0; // 用户手动填写的普通日加班天数
+    const MAX_WORK_DAYS = 26;
 
     // Calculate leave days (rest, leave) - 【修复】不包含带薪休假
     // 【关键修复】休息和请假不算出勤，需要从出勤天数中扣除
@@ -1732,6 +1736,28 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     let holidayOvertimeDays = 0; // 假期加班天数
     let normalOvertimeDays = 0;  // 正常加班天数（修复：现在正常加班也算出勤）
     let autoOvertimeDays = 0;    // 【新增】自动补齐的加班天数
+    const legacyAutoOvertimeDates = new Set();
+
+    // 兼容旧数据：早期自动补齐会保存为月末连续的普通加班记录，没有 is_auto 标记。
+    if (Array.isArray(attendanceData.overtime_records)) {
+        const overtimeByDate = new Map(
+            attendanceData.overtime_records
+                .filter(record => {
+                    if (record.is_auto || (record.daysOffset || 0) !== 0) return false;
+                    const hours = (record.hours || 0) + (record.minutes || 0) / 60;
+                    return hours >= 23.99 && record.startTime === '00:00' && record.endTime === '24:00';
+                })
+                .map(record => [record.date, record])
+        );
+        for (let i = monthDays.length - 1; i >= 0; i--) {
+            const dateStr = format(monthDays[i], 'yyyy-MM-dd');
+            if (overtimeByDate.has(dateStr)) {
+                legacyAutoOvertimeDates.add(dateStr);
+            } else {
+                break;
+            }
+        }
+    }
 
     if (Array.isArray(attendanceData.overtime_records)) {
         attendanceData.overtime_records.forEach(record => {
@@ -1775,8 +1801,12 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
 
             const overtimeDays = hoursInCurrentMonth / 24;
 
-            if (record.is_auto) {
+            const isAutoOvertime = record.is_auto || legacyAutoOvertimeDates.has(record.date);
+
+            if (isAutoOvertime) {
                 autoOvertimeDays += overtimeDays;
+            } else {
+                totalManualOvertimeDays += overtimeDays;
             }
 
             // 将连续的多天加班拆分为每天独立判断，确保精准捕捉连续跨度内的真实法定节假日
@@ -1812,14 +1842,15 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                     holidayOvertimeDays += dailyOvertime;
                 } else {
                     normalOvertimeDays += dailyOvertime;
+                    if (!isAutoOvertime) {
+                        manualNormalOvertimeDays += dailyOvertime;
+                    }
                 }
 
                 currentDay = addDays(currentDay, 1);
             }
         });
     }
-
-    totalOvertimeDays = holidayOvertimeDays + normalOvertimeDays;
 
     // 【新增】计算上户天数（上户当月，上户日不计入出勤天数，按整天扣除；下户当月，下户日计作1整天出勤）
     // 上户：无论几点到达，上户日都不算出勤，扣除整整1天
@@ -1870,10 +1901,18 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     // 公式：出勤天数 = 当月总天数 - 上户天数 + 下户调整 - 休息天数 - 请假天数
     const validDaysCount = monthDays.filter(day => !isDateDisabled(day)).length;
     totalWorkDays = validDaysCount - totalOnboardingDays + offboardingAdjustment - totalLeaveDays;
+    const recalculatedAutoOvertimeDays = Math.max(
+        0,
+        totalWorkDays - MAX_WORK_DAYS - manualNormalOvertimeDays
+    );
+    if (autoOvertimeDays > 0) {
+        autoOvertimeDays = recalculatedAutoOvertimeDays;
+    }
+    const displayAutoOvertimeDays = autoOvertimeDays;
+    totalOvertimeDays = totalManualOvertimeDays + autoOvertimeDays;
 
     // 【关键修复】出勤天数(基本劳务天数)单月最高不超过26天
     // 超过的部分已经在保存时被 autoConvertOvertimeIfNeeded 转换为了 overtime_records
-    const MAX_WORK_DAYS = 26;
     if (totalWorkDays > MAX_WORK_DAYS) {
         totalWorkDays = MAX_WORK_DAYS;
     }
@@ -2009,13 +2048,13 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             {/* Main Content */}
             <div className="max-w-3xl mx-auto p-1 sm:p-4 space-y-4">
                 {/* 自动补齐加班提示 Banner */}
-                {autoOvertimeDays > 0 && (
+                {displayAutoOvertimeDays > 0 && (
                     <div className="bg-emerald-50 border border-emerald-200/80 rounded-2xl p-4 flex items-start gap-3 shadow-sm transition-all duration-300">
                         <span className="text-lg mt-0.5" role="img" aria-label="info">💡</span>
                         <div className="space-y-1">
                             <h4 className="text-sm font-bold text-emerald-900">考勤折算说明</h4>
                             <p className="text-xs text-emerald-700 leading-relaxed">
-                                本月实际工作出勤已超过 <strong>26天</strong> 上限。超出上限的 <strong>{formatDays(autoOvertimeDays)}</strong> 已由系统依据劳务规则自动折算为加班（从月末往前补齐显示），以便于合规计费和维护您的合理权益。
+                                本月实际工作出勤已超过 <strong>26天</strong> 上限。超出上限的 <strong>{formatDays(displayAutoOvertimeDays)}</strong> 已由系统依据劳务规则自动折算为加班（从月末往前补齐显示），以便于合规计费和维护您的合理权益。
                             </p>
                         </div>
                     </div>
@@ -2225,8 +2264,18 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
 
                                 let timeRangeStr = '';
                                 // 上户/下户：不使用默认时间，未填写时显示"待填写"
-                                const startTime = isOnboardingOrOffboarding ? record.startTime : (record.startTime || '09:00');
-                                const endTime = record.endTime || '18:00';
+                                const normalizeDisplayTime = (time) => {
+                                    if (!time) return time;
+                                    const [rawHours, rawMinutes] = String(time).split(':').map(Number);
+                                    if (!Number.isFinite(rawHours) || !Number.isFinite(rawMinutes)) return time;
+                                    const totalMinutes = rawHours * 60 + rawMinutes;
+                                    if (totalMinutes >= 24 * 60) return '24:00';
+                                    const hours = Math.floor(totalMinutes / 60);
+                                    const minutes = totalMinutes % 60;
+                                    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+                                };
+                                const startTime = normalizeDisplayTime(isOnboardingOrOffboarding ? record.startTime : (record.startTime || '09:00'));
+                                const endTime = normalizeDisplayTime(record.endTime || '18:00');
 
                                 if (isOnboardingOrOffboarding) {
                                     // 上户：显示到达时间（startTime）

--- a/frontend/src/utils/attendanceDisplayLogic.js
+++ b/frontend/src/utils/attendanceDisplayLogic.js
@@ -34,7 +34,7 @@ export class AttendanceDisplayLogic {
     static _generateCacheKey(targetDateStr, attendanceRecords) {
         // 使用日期和记录的哈希值作为缓存键
         const recordsHash = attendanceRecords
-            .map(r => `${r.date}_${r.type}_${r.startTime}_${r.endTime}_${r.daysOffset}`)
+            .map(r => `${r.date}_${r.type}_${r.startTime}_${r.endTime}_${r.daysOffset}_${r.is_auto ? 'auto' : 'manual'}`)
             .sort()
             .join('|');
         return `${targetDateStr}:${recordsHash}`;
@@ -142,6 +142,10 @@ export class AttendanceDisplayLogic {
         const startDate = new Date(record.date);
         const daysOffset = record.daysOffset || 0;
         
+        // 系统自动补齐的加班记录需要从月末往前标记，覆盖到的日期都显示为“自动补齐”
+        if (record.type === 'overtime' && record.is_auto) {
+            return true;
+        }
         
         // 单天记录：直接显示
         if (daysOffset === 0) {

--- a/scripts/normalize_attendance_auto_overtime.py
+++ b/scripts/normalize_attendance_auto_overtime.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Normalize legacy auto-filled overtime records in attendance forms.
+
+Dry run:
+    python scripts/normalize_attendance_auto_overtime.py --dry-run
+
+Apply form_data fixes:
+    python scripts/normalize_attendance_auto_overtime.py --apply
+
+Apply and re-sync signed/synced forms into AttendanceRecord/billing:
+    python scripts/normalize_attendance_auto_overtime.py --apply --sync-signed
+"""
+
+import argparse
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+load_dotenv(REPO_ROOT / "backend/.env")
+
+from backend.app import app
+from backend.models import db, AttendanceForm
+from backend.services.attendance_sync_service import (
+    normalize_auto_overtime_form_data,
+    sync_attendance_to_record,
+)
+
+
+def overtime_days(form_data):
+    total_hours = Decimal("0")
+    for record in (form_data or {}).get("overtime_records", []):
+        hours = Decimal(str(record.get("hours", 0) or 0))
+        minutes = Decimal(str(record.get("minutes", 0) or 0))
+        total_hours += hours + minutes / Decimal("60")
+    return total_hours / Decimal("24")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Normalize legacy attendance auto-overtime records."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Only report changes.")
+    parser.add_argument("--apply", action="store_true", help="Write normalized form_data.")
+    parser.add_argument(
+        "--sync-signed",
+        action="store_true",
+        help="After applying, re-sync customer_signed/synced forms to AttendanceRecord and billing.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Limit forms scanned.")
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        raise SystemExit("Use either --dry-run or --apply, not both.")
+    if not args.apply and not args.dry_run:
+        args.dry_run = True
+
+    with app.app_context():
+        query = AttendanceForm.query.filter(AttendanceForm.form_data.isnot(None)).order_by(
+            AttendanceForm.cycle_start_date.asc()
+        )
+        if args.limit:
+            query = query.limit(args.limit)
+
+        scanned = 0
+        changed = 0
+        synced = 0
+        examples = []
+
+        for form in query.yield_per(100):
+            scanned += 1
+            before_data = form.form_data or {}
+            before_days = overtime_days(before_data)
+            normalized_data, is_changed = normalize_auto_overtime_form_data(form)
+
+            if not is_changed:
+                continue
+
+            changed += 1
+            after_days = overtime_days(normalized_data)
+            examples.append(
+                {
+                    "form_id": str(form.id),
+                    "employee_id": str(form.employee_id),
+                    "contract_id": str(form.contract_id),
+                    "cycle": f"{form.cycle_start_date.date()}~{form.cycle_end_date.date()}",
+                    "status": form.status,
+                    "before": str(before_days.quantize(Decimal("0.001"))),
+                    "after": str(after_days.quantize(Decimal("0.001"))),
+                }
+            )
+
+            if args.apply:
+                form.form_data = normalized_data
+                db.session.add(form)
+                db.session.flush()
+
+                if args.sync_signed and form.status in ("customer_signed", "synced"):
+                    sync_attendance_to_record(form.id)
+                    synced += 1
+
+        if args.apply:
+            db.session.commit()
+        else:
+            db.session.rollback()
+
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        print(f"Mode: {mode}")
+        print(f"Scanned forms: {scanned}")
+        print(f"Forms needing normalization: {changed}")
+        if args.apply:
+            print(f"Forms re-synced: {synced}")
+        print("Examples:")
+        for item in examples[:20]:
+            print(
+                f"  {item['cycle']} form={item['form_id']} status={item['status']} "
+                f"overtime {item['before']} -> {item['after']} "
+                f"employee={item['employee_id']} contract={item['contract_id']}"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 允许 pending 状态的自动月签合同参与考勤列表与填写页匹配
- 修复自动补齐加班从月末补齐时遗漏最后一天的问题
- 规范化自动补齐时间，避免生成 22:60 等非法时间
- 修复历史考勤中月末自动补齐加班的展示与统计口径
- 在保存和客户签署同步前规范化自动补齐加班数据，避免工资计算多算
- 新增历史考勤自动补齐批量修复脚本，支持 dry-run、apply 和已签署数据重同步
``` 🚀