### PR TITLE
修复 pending 月签考勤同步与历史自动补齐数据

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,7 @@ backend/scripts/
 scripts/*
 !scripts/cleanup_renewed_nanny_contract_history.py
 !scripts/normalize_attendance_auto_overtime.py
+!scripts/resync_signed_attendance_forms.py
 commit_message.txt
 
 design_proposals/

--- a/backend/services/attendance_sync_service.py
+++ b/backend/services/attendance_sync_service.py
@@ -397,8 +397,8 @@ def sync_attendance_to_record(attendance_form_id):
         # 合同结束日期（如果在当月之前，使用合同结束日期）
         is_monthly_auto_renew = getattr(contract, 'is_monthly_auto_renew', False)
         
-        if is_monthly_auto_renew and contract.status == 'active':
-            # 月签合同（active状态）没有实际固定的结束日期限制
+        if is_monthly_auto_renew and contract.status in ('active', 'pending'):
+            # 月签合同（active/pending状态）没有实际固定的结束日期限制
             contract_end = None
         else:
             contract_end = contract.end_date.date() if getattr(contract, 'end_date', None) and isinstance(contract.end_date, datetime) else getattr(contract, 'end_date', None)

--- a/backend/services/billing_engine.py
+++ b/backend/services/billing_engine.py
@@ -177,7 +177,7 @@ class BillingEngine:
         检查并为自动续约合同创建未来的账单，直到最后一个账单月距离当前月11个月。
         """
         contract = db.session.get(NannyContract, contract_id)
-        if not contract or not contract.is_monthly_auto_renew or contract.status != "active":
+        if not contract or not contract.is_monthly_auto_renew or contract.status not in ("active", "pending"):
             current_app.logger.info(
                 f"[AutoRenewExtend] 合同 {contract_id} 不是有效的自动续约育儿嫂合同，跳过。"
             )

--- a/scripts/resync_signed_attendance_forms.py
+++ b/scripts/resync_signed_attendance_forms.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Re-sync signed attendance forms into AttendanceRecord and billing/payroll.
+
+Dry run:
+    python scripts/resync_signed_attendance_forms.py --year 2026 --month 5 --dry-run
+
+Apply:
+    python scripts/resync_signed_attendance_forms.py --year 2026 --month 5 --apply
+
+Apply for one contract:
+    python scripts/resync_signed_attendance_forms.py --year 2026 --month 5 --contract-id <uuid> --apply
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+load_dotenv(REPO_ROOT / "backend/.env")
+
+from backend.app import app
+from backend.models import AttendanceForm, AttendanceRecord, CustomerBill, EmployeePayroll
+from backend.services.attendance_sync_service import sync_attendance_to_record
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Re-sync signed attendance forms to AttendanceRecord and billing/payroll."
+    )
+    parser.add_argument("--year", type=int, required=True)
+    parser.add_argument("--month", type=int, required=True)
+    parser.add_argument("--contract-id", help="Only sync this contract ID.")
+    parser.add_argument("--dry-run", action="store_true", help="Only report target forms.")
+    parser.add_argument("--apply", action="store_true", help="Run sync_attendance_to_record.")
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        raise SystemExit("Use either --dry-run or --apply, not both.")
+    if not args.apply and not args.dry_run:
+        args.dry_run = True
+
+    with app.app_context():
+        query = AttendanceForm.query.filter(
+            AttendanceForm.cycle_start_date >= f"{args.year}-{args.month:02d}-01",
+            AttendanceForm.cycle_start_date < (
+                f"{args.year + 1}-01-01" if args.month == 12 else f"{args.year}-{args.month + 1:02d}-01"
+            ),
+            AttendanceForm.status.in_(["customer_signed", "synced"]),
+        ).order_by(AttendanceForm.cycle_start_date.asc(), AttendanceForm.updated_at.desc())
+
+        if args.contract_id:
+            query = query.filter(AttendanceForm.contract_id == args.contract_id)
+
+        forms = query.all()
+        print(f"Mode: {'APPLY' if args.apply else 'DRY-RUN'}")
+        print(f"Target signed forms: {len(forms)}")
+
+        synced = 0
+        for form in forms:
+            attendance = AttendanceRecord.query.filter_by(
+                contract_id=form.contract_id,
+                cycle_start_date=form.cycle_start_date,
+            ).first()
+            bill = CustomerBill.query.filter_by(
+                contract_id=form.contract_id,
+                year=args.year,
+                month=args.month,
+                is_substitute_bill=False,
+            ).first()
+            payroll = EmployeePayroll.query.filter_by(
+                contract_id=form.contract_id,
+                year=args.year,
+                month=args.month,
+            ).first()
+
+            print(
+                f"form={form.id} contract={form.contract_id} employee={form.employee_id} "
+                f"status={form.status} signed={bool(form.customer_signed_at)} "
+                f"attendance_record={attendance.id if attendance else None} "
+                f"record_form={attendance.attendance_form_id if attendance else None} "
+                f"bill={bill.id if bill else None} payroll={payroll.id if payroll else None}"
+            )
+
+            if args.apply:
+                sync_attendance_to_record(form.id)
+                synced += 1
+
+        print(f"Synced forms: {synced}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 允许 pending 状态的自动月签合同参与考勤列表、填写页和工资同步
- 修复客户签署后 pending 自动月签合同按合同 end_date 截断的问题
- 修复自动补齐加班从月末补齐时遗漏最后一天的问题
- 规范化自动补齐加班数据，避免工资计算多算加班天数
- 兼容历史月末自动补齐记录并修正展示统计口径
- 新增历史自动补齐批量修复脚本
- 新增已签署考勤表重同步脚本，用于补同步 AttendanceRecord 和工资单
```