### PR TITLE
fix(attendance): 修复上下户月考勤计算与返回跳转

### DIFF
--- a/backend/api/attendance_form_api.py
+++ b/backend/api/attendance_form_api.py
@@ -998,7 +998,21 @@ def get_sign_page_data(signature_token):
         if not form:
             return jsonify({"error": "无效的签署链接"}), 404
 
+        year = request.args.get('year', type=int)
+        month = request.args.get('month', type=int)
         contract_id_param = request.args.get('contractId', type=str)
+        if year and month:
+            employee_token = str(form.employee_id)
+            with current_app.test_request_context(
+                f"/api/attendance-forms/by-token/{employee_token}",
+                query_string={
+                    "year": year,
+                    "month": month,
+                    "contractId": contract_id_param or str(form.contract_id),
+                },
+            ):
+                return get_attendance_form_by_token(employee_token)
+
         if contract_id_param and str(form.contract_id) != contract_id_param:
             corrected_form = AttendanceForm.query.filter(
                 AttendanceForm.contract_id == contract_id_param,
@@ -1254,13 +1268,19 @@ def get_onboarding_time_info(employee_id, contract_id, current_cycle_start):
                     return {
                         'has_onboarding': True,
                         'onboarding_date': onboarding_date,
-                        'onboarding_time': onboarding_time
+                        'onboarding_time': onboarding_time,
+                        'contract_id': str(form.contract_id),
+                        'form_id': str(form.id),
+                        'customer_signature_token': form.customer_signature_token
                     }
         
         return {
             'has_onboarding': False,
             'onboarding_date': None,
-            'onboarding_time': None
+            'onboarding_time': None,
+            'contract_id': None,
+            'form_id': None,
+            'customer_signature_token': None
         }
         
     except Exception as e:
@@ -1268,7 +1288,10 @@ def get_onboarding_time_info(employee_id, contract_id, current_cycle_start):
         return {
             'has_onboarding': False,
             'onboarding_date': None,
-            'onboarding_time': None
+            'onboarding_time': None,
+            'contract_id': None,
+            'form_id': None,
+            'customer_signature_token': None
         }
 
 

--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -1726,6 +1726,35 @@ def miniapp_attendance_sign_detail(signature_token):
     if not form:
         return jsonify({"success": False, "error": "无效的签署链接"}), 404
 
+    year = request.args.get("year", type=int)
+    month = request.args.get("month", type=int)
+    contract_id_param = request.args.get("contractId", type=str)
+    if year and month:
+        from backend.api.attendance_form_api import get_attendance_form_by_token
+
+        employee_token = str(form.employee_id)
+        with current_app.test_request_context(
+            f"/api/attendance-forms/by-token/{employee_token}",
+            query_string={
+                "year": year,
+                "month": month,
+                "contractId": contract_id_param or str(form.contract_id),
+            },
+        ):
+            response = get_attendance_form_by_token(employee_token)
+        flask_response = response[0] if isinstance(response, tuple) else response
+        status_code = response[1] if isinstance(response, tuple) and len(response) > 1 else getattr(flask_response, "status_code", 200)
+        payload = flask_response.get_json(silent=True) or {}
+        if status_code >= 400:
+            return jsonify({"success": False, "error": payload.get("error") or "考勤表加载失败"}), status_code
+        return jsonify(
+            {
+                "success": True,
+                "attendance_form": payload,
+                "auth": _attendance_sign_auth_state(form),
+            }
+        )
+
     cycle_start = form.cycle_start_date.date() if hasattr(form.cycle_start_date, "date") else form.cycle_start_date
     cycle_end = form.cycle_end_date.date() if hasattr(form.cycle_end_date, "date") else form.cycle_end_date
     _, effective_start, effective_end = find_consecutive_contracts(form.employee_id, cycle_start, cycle_end)

--- a/backend/services/attendance_sync_service.py
+++ b/backend/services/attendance_sync_service.py
@@ -32,6 +32,75 @@ def _record_hours(record):
     return Decimal(str(hours)) + Decimal(str(minutes)) / Decimal(60)
 
 
+def _time_to_minutes(time_value):
+    if not time_value:
+        return None
+    try:
+        hour, minute = map(int, str(time_value).split(":"))
+    except (TypeError, ValueError):
+        return None
+    total = hour * 60 + minute
+    if total < 0 or total > 24 * 60:
+        return None
+    return total
+
+
+def _onboarding_time_from_data(data):
+    for record in data.get("onboarding_records") or []:
+        onboarding_time = record.get("startTime")
+        if onboarding_time:
+            return onboarding_time
+    return None
+
+
+def _onboarding_days_to_exclude(data, cycle_start, cycle_end):
+    """上户月不把上户当天计入基础出勤天数。"""
+    dates = set()
+    for record in data.get("onboarding_records") or []:
+        raw_date = record.get("date")
+        if not raw_date:
+            continue
+        try:
+            onboarding_date = _parse_date(raw_date)
+        except (TypeError, ValueError):
+            continue
+        if cycle_start <= onboarding_date <= cycle_end:
+            dates.add(onboarding_date)
+    return Decimal(len(dates))
+
+
+def _contract_valid_days_for_cycle(form, cycle_start, cycle_end):
+    contract = getattr(form, "contract", None)
+    if not contract:
+        return Decimal((cycle_end - cycle_start).days + 1)
+
+    raw_start = getattr(contract, "actual_onboarding_date", None) or contract.start_date
+    contract_start = _parse_date(raw_start)
+    effective_start = max(cycle_start, contract_start)
+
+    contract_end = _attendance_contract_end_date(contract)
+    effective_end = min(cycle_end, contract_end) if contract_end else cycle_end
+    if effective_end < effective_start:
+        return Decimal(0)
+    return Decimal((effective_end - effective_start).days + 1)
+
+
+def _offboarding_adjustment_days(data, onboarding_time):
+    offboarding_time = None
+    for record in data.get("offboarding_records") or []:
+        if record.get("endTime"):
+            offboarding_time = record.get("endTime")
+            break
+
+    onboarding_minutes = _time_to_minutes(onboarding_time)
+    offboarding_minutes = _time_to_minutes(offboarding_time)
+    if onboarding_minutes is None or offboarding_minutes is None:
+        return Decimal(0)
+
+    combined_minutes = Decimal(24 * 60 - onboarding_minutes + offboarding_minutes)
+    return combined_minutes / Decimal(24 * 60) - Decimal("1")
+
+
 def _is_full_day_overtime(record):
     return (
         record.get("type") == "overtime"
@@ -103,8 +172,15 @@ def normalize_auto_overtime_form_data(form):
         if not _is_statutory_holiday(record_date):
             manual_normal_overtime_days += _record_hours(record) / Decimal(24)
 
-    valid_days_count = Decimal(len(month_days))
-    total_work_days_before_cap = valid_days_count - total_leave_days
+    valid_days_count = _contract_valid_days_for_cycle(form, cycle_start, cycle_end)
+    onboarding_days = _onboarding_days_to_exclude(data, cycle_start, cycle_end)
+    onboarding_time = _onboarding_time_from_data(data)
+    if not onboarding_time:
+        onboarding_info = get_onboarding_time_for_contract(form.employee_id, form.contract_id)
+        if onboarding_info.get("has_onboarding"):
+            onboarding_time = onboarding_info.get("onboarding_time")
+    offboarding_adjustment = _offboarding_adjustment_days(data, onboarding_time)
+    total_work_days_before_cap = valid_days_count - onboarding_days + offboarding_adjustment - total_leave_days
     auto_overtime_days = total_work_days_before_cap - Decimal("26") - manual_normal_overtime_days
     if auto_overtime_days <= 0:
         auto_overtime_days = Decimal(0)
@@ -212,14 +288,20 @@ def get_onboarding_time_for_contract(employee_id, contract_id):
                     return {
                         'has_onboarding': True,
                         'onboarding_date': onboarding_date,
-                        'onboarding_time': onboarding_time
+                        'onboarding_time': onboarding_time,
+                        'contract_id': str(form.contract_id),
+                        'form_id': str(form.id),
+                        'customer_signature_token': form.customer_signature_token
                     }
         
         current_app.logger.warning(f"[GET_ONBOARDING] 未找到合同 {contract_id} 的上户记录")
         return {
             'has_onboarding': False,
             'onboarding_date': None,
-            'onboarding_time': None
+            'onboarding_time': None,
+            'contract_id': None,
+            'form_id': None,
+            'customer_signature_token': None
         }
         
     except Exception as e:
@@ -227,7 +309,10 @@ def get_onboarding_time_for_contract(employee_id, contract_id):
         return {
             'has_onboarding': False,
             'onboarding_date': None,
-            'onboarding_time': None
+            'onboarding_time': None,
+            'contract_id': None,
+            'form_id': None,
+            'customer_signature_token': None
         }
 
 
@@ -256,8 +341,8 @@ def calculate_offboarding_work_days(onboarding_time, offboarding_date, offboardi
         offboarding_hour, offboarding_minute = map(int, offboarding_time.split(':'))
         offboarding_hours = offboarding_hour + offboarding_minute / 60
         
-        # 上户日实际出勤（上户日已算作满额1天正常出勤，即24小时）
-        onboarding_day_work = 24
+        # 上户日不计入首月基础出勤，剩余小时在下户月与下户当天合并计算。
+        onboarding_day_work = max(0, 24 - onboarding_hours)
         
         # 下户日实际出勤（00:00到下户时间）
         offboarding_day_work = offboarding_hours
@@ -352,17 +437,19 @@ def sync_attendance_to_record(attendance_form_id):
     out_of_country_days = calculate_days(data.get('out_of_country_records', []))  # 修复：使用正确的键名
     paid_leave_days = calculate_days(data.get('paid_leave_records', []))
     
+    cycle_start = _parse_date(form.cycle_start_date)
+    cycle_end = _parse_date(form.cycle_end_date)
+
     # 【新增】上户/下户特殊处理
     onboarding_records = data.get('onboarding_records', [])
     offboarding_records = data.get('offboarding_records', [])
     
-    # 考勤中的“上户”那天要算作“出勤”天数，因此不扣除
-    onboarding_days = Decimal(0)
+    # 上户月不把上户当天计入基础出勤；该日剩余小时留到下户月合并计算。
+    onboarding_days = _onboarding_days_to_exclude(data, cycle_start, cycle_end)
     
-    # 下户天数：下户当月，下户日计作出勤
-    # 需要根据上户时间和下户时间计算下户日的实际出勤
+    # 下户月需要把首月上户日剩余小时与下户日已工作小时合并计算。
     offboarding_days = Decimal(0)
-    offboarding_day_work = Decimal(0)  # 下户日的实际出勤天数
+    offboarding_day_work = Decimal(0)  # 上户日剩余小时 + 下户日已工作小时折算出的天数
     onboarding_time_info = None
     offboarding_time_info = None
     
@@ -391,20 +478,20 @@ def sync_attendance_to_record(attendance_form_id):
             }
         
         if onboarding_info['has_onboarding'] and offboarding_time:
-            # 计算下户日的实际出勤天数
+            # 计算上户日剩余小时 + 下户日已工作小时折算出的天数
             offboarding_day_work = calculate_offboarding_work_days(
                 onboarding_info['onboarding_time'],
                 offboarding_date,
                 offboarding_time
             )
             
-            current_app.logger.info(f"[ATTENDANCE_SYNC] 下户月计算 - 上户时间:{onboarding_info['onboarding_time']}, 下户时间:{offboarding_time}, 下户日出勤:{offboarding_day_work}天")
+            current_app.logger.info(f"[ATTENDANCE_SYNC] 下户月计算 - 上户时间:{onboarding_info['onboarding_time']}, 下户时间:{offboarding_time}, 合并出勤:{offboarding_day_work}天")
         else:
             # 如果没有上户时间信息，下户日按1整天计算
             offboarding_day_work = Decimal('1')
             current_app.logger.warning(f"[ATTENDANCE_SYNC] 未找到上户时间信息，下户日按1整天计算")
     
-    current_app.logger.info(f"[ATTENDANCE_SYNC] 计算结果 - 休息:{rest_days}, 请假:{leave_days}, 带薪休假:{paid_leave_days}, 加班:{overtime_days}, 出京:{out_of_beijing_days}, 出境:{out_of_country_days}, 上户:{onboarding_days}, 下户日出勤:{offboarding_day_work}")
+    current_app.logger.info(f"[ATTENDANCE_SYNC] 计算结果 - 休息:{rest_days}, 请假:{leave_days}, 带薪休假:{paid_leave_days}, 加班:{overtime_days}, 出京:{out_of_beijing_days}, 出境:{out_of_country_days}, 上户扣除:{onboarding_days}, 合并出勤:{offboarding_day_work}")
     
     # 3. 计算总出勤天数
     # 逻辑: 合同有效天数 - 休息天数 - 请假天数
@@ -415,12 +502,9 @@ def sync_attendance_to_record(attendance_form_id):
     # 【关键修复】使用合同的有效日期范围，而不是整个考勤周期
     contract = form.contract
     if contract:
-        # 计算合同在当月的有效天数
-        cycle_start = form.cycle_start_date.date() if isinstance(form.cycle_start_date, datetime) else form.cycle_start_date
-        cycle_end = form.cycle_end_date.date() if isinstance(form.cycle_end_date, datetime) else form.cycle_end_date
-        
-        # 合同开始日期（如果在当月之后，使用合同开始日期）
-        contract_start = contract.start_date.date() if isinstance(contract.start_date, datetime) else contract.start_date
+        # 合同开始日期（如果有实际上户日，优先使用实际上户日）
+        raw_contract_start = getattr(contract, 'actual_onboarding_date', None) or contract.start_date
+        contract_start = raw_contract_start.date() if isinstance(raw_contract_start, datetime) else raw_contract_start
         effective_start = max(cycle_start, contract_start)
         
         contract_end = _attendance_contract_end_date(contract)
@@ -436,20 +520,13 @@ def sync_attendance_to_record(attendance_form_id):
         current_app.logger.info(f"[ATTENDANCE_SYNC] 合同有效期: {effective_start} 到 {effective_end}, 基础劳务天数: {base_work_days}")
     else:
         # 如果没有合同信息，回退到使用考勤周期
-        base_work_days = (form.cycle_end_date.date() - form.cycle_start_date.date()).days + 1
+        base_work_days = (cycle_end - cycle_start).days + 1
         current_app.logger.warning(f"[ATTENDANCE_SYNC] 未找到合同信息，使用考勤周期天数: {base_work_days}")
     
-    # 出勤天数 = 基础劳务天数 - 休息天数 - 请假天数 - 上户天数
-    # 【新增】上户不计算出勤天数，下户计算出勤天数
-    # 【下户月特殊处理】如果有下户记录，需要调整
+    # 出勤天数 = 基础劳务天数 - 休息天数 - 请假天数 - 上户日 + 末月小时合并调整
     if offboarding_records and offboarding_day_work > 0:
-        # 下户月计算逻辑：
-        # offboarding_day_work = 上户日实际出勤(24-上户时间) + 下户日实际出勤(下户时间)
-        # 基础天数已经包含了下户日作为完整1天
-        # 需要：减去下户日多算的部分，加上上户日补回的部分
-        # 调整 = offboarding_day_work - 1（因为下户日已经算了1天，实际应该是 offboarding_day_work 天）
-        # 但 offboarding_day_work 包含了上户日补回，所以：
-        # 总出勤 = 基础天数 - 1（下户日） + offboarding_day_work
+        # offboarding_day_work = (上户日 24:00-上户时间) + (下户日 00:00-下户时间)
+        # 基础天数已包含下户日 1 天，因此先减 1 天再加回合并小时。
         total_days_worked = Decimal(base_work_days) - rest_days - leave_days - onboarding_days - Decimal('1') + offboarding_day_work
         current_app.logger.info(f"[ATTENDANCE_SYNC] 下户月调整 - 基础:{base_work_days}, 上户日+下户日出勤:{offboarding_day_work}, 调整后出勤:{total_days_worked}")
     else:

--- a/frontend/src/components/attendance/AttendanceFillPage.jsx
+++ b/frontend/src/components/attendance/AttendanceFillPage.jsx
@@ -4,7 +4,7 @@ import { format, parseISO, addDays, setHours, setMinutes, isSameDay, startOfDay,
 import { zhCN } from 'date-fns/locale';
 import api from '../../api/axios';
 import { useToast } from '../ui/use-toast';
-import { Loader2, CheckCircle2, AlertCircle, Save, Send, X, Clock, ChevronRight, ChevronLeft, ArrowRight, Copy, Check, Share2, Eraser, CalendarIcon } from 'lucide-react';
+import { Loader2, CheckCircle2, AlertCircle, Save, Send, X, Clock, ChevronRight, ChevronLeft, ArrowRight, ArrowLeft, Copy, Check, Share2, Eraser, CalendarIcon } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "../../utils";
 import SignatureCanvas from 'react-signature-canvas';
@@ -32,48 +32,12 @@ const formatDuration = (hours, minutes = 0) => {
         totalHours = hours + minutes / 60;
     }
 
-    if (totalHours < 24) {
-        // Less than 24 hours: show hours without unnecessary decimal places
-        const formattedHours = Number(totalHours.toFixed(2));
-        return `${formattedHours}小时`;
-    } else {
-        // 24 hours or more: show as days and hours
-        const days = Math.floor(totalHours / 24);
-        const remainingHours = totalHours % 24;
-
-        if (remainingHours === 0) {
-            return `${days}天`;
-        }
-
-        // 如果剩余小时数是整数，直接显示；否则保留一位小数
-        const formattedRemaining = remainingHours % 1 === 0
-            ? remainingHours
-            : Number(remainingHours.toFixed(2));
-
-        return `${days}天${formattedRemaining}小时`;
-    }
+    return `${(totalHours / 24).toFixed(2)}天`;
 };
 
 // Helper function to format days (for summary display)
 const formatDays = (totalDays) => {
-    if (totalDays === 0) return '0';
-    const days = Math.floor(totalDays);
-    const remainingHours = (totalDays - days) * 24;
-
-    // 如果没有余数小时，仅显示天数
-    if (remainingHours <= 0.01) { // 极小余数忽略
-        return `${days}`;
-    }
-
-    // 格式化余数小时：如果是整数则不带小数，否则带1-2位小数
-    const formattedHours = remainingHours % 1 === 0
-        ? remainingHours
-        : Number(remainingHours.toFixed(2));
-
-    if (days === 0) {
-        return `${formattedHours}小时`;
-    }
-    return `${days}天${formattedHours}小时`;
+    return `${Number(totalDays || 0).toFixed(2)}天`;
 };
 
 const timeToMinutesForDisplay = (time, fallback = 0) => {
@@ -87,6 +51,141 @@ const isFullDayDisplayRecord = (record = {}) => {
     const startMinutes = timeToMinutesForDisplay(record.startTime || '00:00', 0);
     const endMinutes = timeToMinutesForDisplay(record.endTime || '24:00', 24 * 60);
     return startMinutes <= 0 && endMinutes >= 24 * 60;
+};
+
+const parseDateOnlyForAttendance = (value) => {
+    if (!value) return null;
+    const parsed = startOfDay(parseISO(String(value).slice(0, 10)));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const getOnboardingTimeForAttendance = (formData, attendanceData) => {
+    const infoTime = formData?.onboarding_time_info?.onboarding_time;
+    if (infoTime) return infoTime;
+    const onboardingRecord = attendanceData?.onboarding_records?.find(record => record.startTime);
+    return onboardingRecord?.startTime || null;
+};
+
+const getOnboardingReferenceForAttendance = (formData, attendanceData) => {
+    const info = formData?.onboarding_time_info || {};
+    if (info?.onboarding_time) {
+        return {
+            date: info.onboarding_date || null,
+            time: info.onboarding_time,
+            contractId: info.contract_id || null,
+            signatureToken: info.customer_signature_token || null
+        };
+    }
+
+    const onboardingRecord = attendanceData?.onboarding_records?.find(record => record.startTime);
+    if (!onboardingRecord) return null;
+    return {
+        date: onboardingRecord.date || null,
+        time: onboardingRecord.startTime,
+        contractId: onboardingRecord.contract_id || null,
+        signatureToken: onboardingRecord.customer_signature_token || null
+    };
+};
+
+const normalizeAttendanceTimeText = (time) => {
+    if (!time) return '';
+    const minutes = timeToMinutesForDisplay(time, NaN);
+    if (!Number.isFinite(minutes)) return String(time);
+    if (minutes >= 24 * 60) return '24:00';
+    const hours = Math.floor(minutes / 60);
+    const minute = minutes % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+};
+
+const formatAttendanceMonthDay = (date) => {
+    const parsed = parseDateOnlyForAttendance(date);
+    return parsed ? format(parsed, 'M月d日') : '';
+};
+
+const formatDayTextForNote = (days) => {
+    const value = Number(days || 0);
+    if (Math.abs(value - 1) < 0.005) return '1天';
+    return formatDays(value);
+};
+
+const calculateOnboardingDaysToExclude = (attendanceData, formData) => {
+    const startDate = parseDateOnlyForAttendance(formData?.cycle_start_date);
+    const endDate = parseDateOnlyForAttendance(formData?.cycle_end_date);
+    if (!startDate || !endDate) return 0;
+
+    const onboardingDates = new Set();
+    (attendanceData?.onboarding_records || []).forEach(record => {
+        const onboardingDate = parseDateOnlyForAttendance(record.date);
+        if (onboardingDate && onboardingDate >= startDate && onboardingDate <= endDate) {
+            onboardingDates.add(format(onboardingDate, 'yyyy-MM-dd'));
+        }
+    });
+
+    const infoDate = parseDateOnlyForAttendance(formData?.onboarding_time_info?.onboarding_date);
+    if (infoDate && infoDate >= startDate && infoDate <= endDate) {
+        onboardingDates.add(format(infoDate, 'yyyy-MM-dd'));
+    }
+
+    return onboardingDates.size;
+};
+
+const calculateOffboardingAdjustment = (attendanceData, formData) => {
+    const offboardingRecord = attendanceData?.offboarding_records?.find(record => record.endTime);
+    const onboardingTime = getOnboardingTimeForAttendance(formData, attendanceData);
+    const offboardingTime = offboardingRecord?.endTime;
+    if (!onboardingTime || !offboardingTime) return 0;
+
+    const onboardingMinutes = timeToMinutesForDisplay(onboardingTime, NaN);
+    const offboardingMinutes = timeToMinutesForDisplay(offboardingTime, NaN);
+    if (!Number.isFinite(onboardingMinutes) || !Number.isFinite(offboardingMinutes)) return 0;
+
+    const combinedMinutes = (24 * 60 - onboardingMinutes) + offboardingMinutes;
+    return combinedMinutes / (24 * 60) - 1;
+};
+
+const getSpecialRecordDetailText = (record, formData, attendanceData) => {
+    if (record?.type === 'onboarding') {
+        const onboardingTime = normalizeAttendanceTimeText(record.startTime);
+        if (!onboardingTime) return '';
+        return `上户日 ${onboardingTime}~24:00 会在下户日当天计算考勤，本月不计算上户日当天考勤`;
+    }
+
+    if (record?.type === 'offboarding') {
+        const ref = getOnboardingReferenceForAttendance(formData, attendanceData);
+        const onboardingTime = normalizeAttendanceTimeText(ref?.time);
+        const offboardingTime = normalizeAttendanceTimeText(record.endTime);
+        if (!onboardingTime || !offboardingTime) return '';
+        const refDateText = formatAttendanceMonthDay(ref?.date);
+        const offboardingDateText = formatAttendanceMonthDay(record.date);
+        const onboardingMinutes = timeToMinutesForDisplay(ref.time, 0);
+        const offboardingMinutes = timeToMinutesForDisplay(record.endTime, 0);
+        const baseEndTime = normalizeAttendanceTimeText(ref.time);
+        const baseText = `${refDateText ? `${refDateText} ` : '上户日 '}${onboardingTime}~${offboardingDateText ? `${offboardingDateText} ` : '下户日 '}${baseEndTime} 算作1天`;
+        const deltaMinutes = offboardingMinutes - onboardingMinutes;
+        if (deltaMinutes > 0) {
+            return `${baseText}；下户日 ${baseEndTime}~${offboardingTime} 另计${formatDays(deltaMinutes / (24 * 60))}`;
+        }
+        if (deltaMinutes < 0) {
+            const combinedDays = ((24 * 60 - onboardingMinutes) + offboardingMinutes) / (24 * 60);
+            return `${baseText}；下户早于上户时间，合并计${formatDayTextForNote(combinedDays)}`;
+        }
+        return baseText;
+    }
+
+    return '';
+};
+
+const getOnboardingAttendanceLink = (record, formData, attendanceData) => {
+    if (record?.type !== 'offboarding') return null;
+    const ref = getOnboardingReferenceForAttendance(formData, attendanceData);
+    const date = parseDateOnlyForAttendance(ref?.date);
+    if (!date) return null;
+    return {
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        contractId: ref.contractId || null,
+        signatureToken: ref.signatureToken || null
+    };
 };
 
 const ATTENDANCE_TYPES = {
@@ -258,10 +357,18 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
         const year = searchParams.get('year');
         const month = searchParams.get('month');
         const contractId = searchParams.get('contractId');
+        const returnYear = searchParams.get('returnYear');
+        const returnMonth = searchParams.get('returnMonth');
+        const returnContractId = searchParams.get('returnContractId');
+        const returnSignatureToken = searchParams.get('returnSignatureToken');
         return {
             year: year ? parseInt(year, 10) : null,
             month: month ? parseInt(month, 10) : null,
-            contractId: contractId || null
+            contractId: contractId || null,
+            returnYear: returnYear ? parseInt(returnYear, 10) : null,
+            returnMonth: returnMonth ? parseInt(returnMonth, 10) : null,
+            returnContractId: returnContractId || null,
+            returnSignatureToken: returnSignatureToken || null
         };
     }, [location.search]);
 
@@ -275,6 +382,20 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     // 初始值：优先使用 URL 参数或 token 中的年月，否则为 null（让后端智能选择）
     const [selectedYear, setSelectedYear] = useState(() => urlParams.year || initialYear || null);
     const [selectedMonth, setSelectedMonth] = useState(() => urlParams.month || initialMonth || null);
+    const [selectedContractId, setSelectedContractId] = useState(() => urlParams.contractId || null);
+    const [formData, setFormData] = useState(null);
+    const [attendanceData, setAttendanceData] = useState({
+        rest_records: [],
+        leave_records: [],
+        overtime_records: [],
+        out_of_beijing_records: [],
+        out_of_country_records: [],
+        paid_leave_records: [],
+        onboarding_records: [],
+        offboarding_records: []
+    });
+    const [monthDays, setMonthDays] = useState([]);
+    const [contractInfo, setContractInfo] = useState(null);
 
     // 更新 URL 参数的函数（不刷新页面）
     const updateUrlParams = useCallback((year, month, contractId = null) => {
@@ -290,13 +411,107 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     }, [location.pathname, location.search]);
 
     // 切换月份的函数
-    const handleMonthChange = useCallback((year, month) => {
+    const handleMonthChange = useCallback((year, month, contractId = selectedContractId) => {
         // 清除上次请求记录，确保会重新请求
-        lastFetchedMonth.current = { year: null, month: null };
+        lastFetchedMonth.current = { year: null, month: null, contractId: null };
         setSelectedYear(year);
         setSelectedMonth(month);
-        updateUrlParams(year, month);
-    }, [updateUrlParams]);
+        if (contractId) setSelectedContractId(contractId);
+        updateUrlParams(year, month, contractId);
+    }, [selectedContractId, updateUrlParams]);
+
+    const jumpToAttendanceMonth = useCallback((year, month, targetContractId = null, targetSignatureToken = null) => {
+        if (!year || !month) return;
+        const nextContractId = targetContractId || selectedContractId || formData?.contract_id || urlParams.contractId || null;
+        const returnYear = selectedYear || formData?.actual_year || formData?.year || urlParams.year;
+        const returnMonth = selectedMonth || formData?.actual_month || formData?.month || urlParams.month;
+        const returnContractId = selectedContractId || formData?.contract_id || urlParams.contractId;
+        if (isCustomerMode) {
+            const searchParams = new URLSearchParams(location.search);
+            searchParams.set('year', year.toString());
+            searchParams.set('month', month.toString());
+            if (nextContractId) searchParams.set('contractId', nextContractId);
+
+            if (returnYear && returnMonth) {
+                searchParams.set('returnYear', returnYear.toString());
+                searchParams.set('returnMonth', returnMonth.toString());
+                if (returnContractId) searchParams.set('returnContractId', returnContractId);
+                if (realToken) searchParams.set('returnSignatureToken', realToken);
+            }
+
+            const targetPath = targetSignatureToken
+                ? location.pathname.replace(realToken, targetSignatureToken)
+                : location.pathname;
+            navigate(`${targetPath}?${searchParams.toString()}`);
+            return;
+        }
+        lastFetchedMonth.current = { year: null, month: null, contractId: null };
+        setSelectedContractId(nextContractId);
+        setSelectedYear(year);
+        setSelectedMonth(month);
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('year', year.toString());
+        searchParams.set('month', month.toString());
+        if (nextContractId) {
+            searchParams.set('contractId', nextContractId);
+        } else {
+            searchParams.delete('contractId');
+        }
+        if (returnYear && returnMonth) {
+            searchParams.set('returnYear', returnYear.toString());
+            searchParams.set('returnMonth', returnMonth.toString());
+            if (returnContractId) {
+                searchParams.set('returnContractId', returnContractId);
+            } else {
+                searchParams.delete('returnContractId');
+            }
+        }
+        navigate(`${location.pathname}?${searchParams.toString()}`, { replace: true });
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }, [formData, isCustomerMode, location.pathname, location.search, navigate, realToken, selectedContractId, selectedMonth, selectedYear, urlParams.contractId, urlParams.month, urlParams.year]);
+
+    const returnAttendanceLink = useMemo(() => {
+        if (!urlParams.returnYear || !urlParams.returnMonth) return null;
+
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('year', urlParams.returnYear.toString());
+        searchParams.set('month', urlParams.returnMonth.toString());
+        if (urlParams.returnContractId) {
+            searchParams.set('contractId', urlParams.returnContractId);
+        } else {
+            searchParams.delete('contractId');
+        }
+        searchParams.delete('returnYear');
+        searchParams.delete('returnMonth');
+        searchParams.delete('returnContractId');
+        searchParams.delete('returnSignatureToken');
+
+        const targetPath = urlParams.returnSignatureToken
+            ? location.pathname.replace(realToken, urlParams.returnSignatureToken)
+            : location.pathname;
+
+        return `${targetPath}?${searchParams.toString()}`;
+    }, [location.pathname, location.search, realToken, urlParams.returnContractId, urlParams.returnMonth, urlParams.returnSignatureToken, urlParams.returnYear]);
+
+    const goBackToReturnAttendance = useCallback(() => {
+        if (returnAttendanceLink) {
+            if (isCustomerMode) {
+                navigate(returnAttendanceLink);
+                return;
+            }
+            const targetUrl = new URL(returnAttendanceLink, window.location.origin);
+            const year = Number(targetUrl.searchParams.get('year'));
+            const month = Number(targetUrl.searchParams.get('month'));
+            const contractId = targetUrl.searchParams.get('contractId') || null;
+            if (!year || !month) return;
+            lastFetchedMonth.current = { year: null, month: null, contractId: null };
+            setSelectedContractId(contractId);
+            setSelectedYear(year);
+            setSelectedMonth(month);
+            navigate(`${location.pathname}${targetUrl.search}`, { replace: true });
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    }, [isCustomerMode, location.pathname, navigate, returnAttendanceLink]);
 
     // Update selected year/month if token changes and has suffix
     useEffect(() => {
@@ -305,20 +520,6 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             setSelectedMonth(initialMonth);
         }
     }, [initialYear, initialMonth]);
-
-    const [formData, setFormData] = useState(null);
-    const [attendanceData, setAttendanceData] = useState({
-        rest_records: [],
-        leave_records: [],
-        overtime_records: [],
-        out_of_beijing_records: [],
-        out_of_country_records: [],
-        paid_leave_records: [],
-        onboarding_records: [],
-        offboarding_records: []
-    });
-    const [monthDays, setMonthDays] = useState([]);
-    const [contractInfo, setContractInfo] = useState(null);
 
     // 上月出京/出境延续信息（用于判断本月是否需要满30天）
     const previousMonthContinuation = useMemo(() => {
@@ -329,7 +530,16 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     const hasAdjustedForContractMonth = useRef(false);
 
     // 跟踪最后一次成功请求的年月，避免重复请求
-    const lastFetchedMonth = useRef({ year: null, month: null });
+    const lastFetchedMonth = useRef({ year: null, month: null, contractId: null });
+
+    useEffect(() => {
+        setSelectedContractId(urlParams.contractId || null);
+        if (urlParams.year && urlParams.month) {
+            lastFetchedMonth.current = { year: null, month: null, contractId: null };
+            setSelectedYear(urlParams.year);
+            setSelectedMonth(urlParams.month);
+        }
+    }, [urlParams.year, urlParams.month, urlParams.contractId]);
 
     // 注意：默认月份的智能选择已由后端处理，前端不再需要额外的调整逻辑
     // 后端会根据合同开始/结束月份返回 actual_year 和 actual_month
@@ -572,9 +782,9 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
     useEffect(() => {
         // 只有当realToken存在时才调用fetchData
         if (realToken) {
-            fetchData(selectedYear, selectedMonth);
+            fetchData(selectedYear, selectedMonth, selectedContractId);
         }
-    }, [realToken, selectedYear, selectedMonth]);
+    }, [realToken, selectedYear, selectedMonth, selectedContractId]);
 
     // 检查是否需要显示分享提示遮罩
     // 使用 sessionStorage 传递状态，避免 URL 参数被分享出去
@@ -619,10 +829,15 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
         return () => window.removeEventListener('scroll', handleScroll);
     }, [isScrolled]);
 
-    const fetchData = async (year = selectedYear, month = selectedMonth) => {
+    const fetchData = async (year = selectedYear, month = selectedMonth, contractId = selectedContractId) => {
         try {
             // 如果请求的年月与上次成功请求的相同，跳过（避免重复请求）
-            if (lastFetchedMonth.current.year === year && lastFetchedMonth.current.month === month && formData) {
+            if (
+                lastFetchedMonth.current.year === year &&
+                lastFetchedMonth.current.month === month &&
+                lastFetchedMonth.current.contractId === (contractId || null) &&
+                formData
+            ) {
                 console.log(`[fetchData] Skipping duplicate request for ${year}-${month}`);
                 return;
             }
@@ -641,20 +856,29 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                 ? `/attendance-forms/sign/${realToken}`  // 客户签署模式
                 : `/attendance-forms/by-token/${realToken}`;  // 员工填写模式或管理员查看模式
 
-            if (isCustomerMode && urlParams.contractId) {
-                endpoint += `?contractId=${urlParams.contractId}`;
+            if (isCustomerMode) {
+                const params = new URLSearchParams();
+                if (year && month) {
+                    params.set('year', year);
+                    params.set('month', month);
+                }
+                if (contractId) {
+                    params.set('contractId', contractId);
+                }
+                const query = params.toString();
+                if (query) endpoint += `?${query}`;
             }
 
             // 添加月份参数 (仅员工模式)
             if (!isCustomerMode && year && month) {
                 endpoint += `?year=${year}&month=${month}`;
                 // 如果有 contractId，也传递给后端
-                if (urlParams.contractId) {
-                    endpoint += `&contractId=${urlParams.contractId}`;
+                if (contractId) {
+                    endpoint += `&contractId=${contractId}`;
                 }
-            } else if (!isCustomerMode && urlParams.contractId) {
+            } else if (!isCustomerMode && contractId) {
                 // 没有年月参数但有 contractId
-                endpoint += `?contractId=${urlParams.contractId}`;
+                endpoint += `?contractId=${contractId}`;
             }
 
             const response = await api.get(endpoint);
@@ -671,8 +895,10 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             // 记录成功请求的年月（使用后端返回的实际年月）
             lastFetchedMonth.current = {
                 year: data.actual_year || actualYear,
-                month: data.actual_month || actualMonth
+                month: data.actual_month || actualMonth,
+                contractId: data.contract_id || contractId || null
             };
+            setSelectedContractId(data.contract_id || contractId || null);
 
             if (data.actual_year && data.actual_month) {
                 // 始终更新前端状态为后端返回的实际年月
@@ -680,7 +906,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                 setSelectedMonth(data.actual_month);
                 // 同时保存 contract_id 到 URL（如果还没有的话）
                 updateUrlParams(data.actual_year, data.actual_month, data.contract_id);
-            } else if (data.contract_id && !urlParams.contractId) {
+            } else if (data.contract_id && !contractId) {
                 // 即使没有年月变化，也要保存 contract_id
                 const searchParams = new URLSearchParams(location.search);
                 searchParams.set('contractId', data.contract_id);
@@ -1429,12 +1655,15 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             });
         }
 
+        const onboardingDaysToExclude = calculateOnboardingDaysToExclude(data, formData);
+        const offboardingAdjustment = calculateOffboardingAdjustment(data, formData);
+
         // 计算有效天数（合同范围内的天数）
         const validDaysCount = monthDays.filter(day => !isDateDisabled(day)).length;
 
         // 【关键修复】待分配出勤天数 = 有效天数 - 休息请假天数 - 普通加班天数
         // 【重要】确定的法定节假日加班是“额外”奖金，不消耗物理出勤天数的名额，因此不减去 holidayOvertimeDays
-        const currentWorkDays = validDaysCount - totalLeaveDays - normalOvertimeDays;
+        const currentWorkDays = validDaysCount - onboardingDaysToExclude + offboardingAdjustment - totalLeaveDays - normalOvertimeDays;
 
         // 如果出勤天数 <= 26，不需要处理
         if (currentWorkDays <= MAX_WORK_DAYS) {
@@ -1856,53 +2085,14 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
         });
     }
 
-    // 【新增】计算上户天数（上户当月，上户日不计入出勤天数，按整天扣除；下户当月，下户日计作1整天出勤）
-    // 上户：无论几点到达，上户日都不算出勤，扣除整整1天
-    // 下户：需要根据上户时间和下户时间计算实际出勤
-    let totalOnboardingDays = 0;
-    if (Array.isArray(attendanceData.onboarding_records)) {
-        attendanceData.onboarding_records.forEach(() => {
-            // 考勤中的”上户“那天要算作”出勤“天数，因此不扣除
-            totalOnboardingDays += 0;
-        });
-    }
-
-    // 【下户月特殊处理】计算上户日补回 + 下户日出勤
-    let offboardingAdjustment = 0;
-    if (Array.isArray(attendanceData.offboarding_records) && attendanceData.offboarding_records.length > 0) {
-        const offboardingRecord = attendanceData.offboarding_records[0];
-        const offboardingTime = offboardingRecord.endTime; // 下户时间存储在 endTime 中
-
-        // 获取上户时间（优先从后端返回的信息获取，否则从当前月份的考勤数据获取）
-        const onboardingInfo = formData?.onboarding_time_info;
-        const onboardingTime = onboardingInfo?.onboarding_time ||
-            (attendanceData.onboarding_records?.[0]?.startTime);
-
-        if (onboardingTime && offboardingTime) {
-            // 解析上户时间
-            const [onboardingHour, onboardingMinute] = onboardingTime.split(':').map(Number);
-            const onboardingHours = onboardingHour + (onboardingMinute || 0) / 60;
-
-            // 解析下户时间
-            const [offboardingHour, offboardingMinute] = offboardingTime.split(':').map(Number);
-            const offboardingHours = offboardingHour + (offboardingMinute || 0) / 60;
-
-            // 上户日实际出勤（上户日已算作满额1天正常出勤，即24小时）+ 下户日实际出勤（00:00到下户时间）
-            const onboardingDayWork = 24;
-            const offboardingDayWork = offboardingHours;
-            const totalExtraHours = onboardingDayWork + offboardingDayWork;
-
-            // 调整量 = 额外出勤 - 1（因为下户日已经算了1天）
-            offboardingAdjustment = totalExtraHours / 24 - 1;
-        }
-    }
+    const totalOnboardingDays = calculateOnboardingDaysToExclude(attendanceData, formData);
+    const offboardingAdjustment = calculateOffboardingAdjustment(attendanceData, formData);
 
     // Work days (基本劳务天数) = valid days - onboarding days + offboarding adjustment - leave days
     // 【关键修复】法定节假日算出勤（带薪假期），休息和请假不算出勤
     // 【重要】无论是"假期加班"还是"正常加班"均算出勤，不需要扣除
     // 带薪休假、出京、出境都算作出勤天数，不需要扣除
-    // 【新增】上户不计算出勤天数，需要扣除；下户月需要加上调整量
-    // 公式：出勤天数 = 当月总天数 - 上户天数 + 下户调整 - 休息天数 - 请假天数
+    // 上户月：上户当天不计入基础出勤；下户月：上户日剩余小时与下户日小时合并计算。
     const validDaysCount = monthDays.filter(day => !isDateDisabled(day)).length;
     totalWorkDays = validDaysCount - totalOnboardingDays + offboardingAdjustment - totalLeaveDays;
     const recalculatedAutoOvertimeDays = Math.max(
@@ -2011,10 +2201,12 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                 })()}
                             </div>
 
-                            {/* User 图标 */}
-                            <div className={`rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-bold transition-all duration-300
-                                ${isScrolled ? 'h-8 w-8 text-xs' : 'h-10 w-10 text-sm'}`}>
-                                {contractInfo?.employee_name?.slice(-2) || 'User'}
+                            <div className="flex items-center gap-2 flex-shrink-0">
+                                {/* User 图标 */}
+                                <div className={`rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-bold transition-all duration-300
+                                    ${isScrolled ? 'h-8 w-8 text-xs' : 'h-10 w-10 text-sm'}`}>
+                                    {contractInfo?.employee_name?.slice(-2) || 'User'}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -2283,7 +2475,17 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                     ? `${format(startDate, 'M月d日')} ~ ${format(endDate, 'M月d日')}`
                                     : format(startDate, 'M月d日');
                                 let timeRangeStr = dateRangeStr;
-                                const durationText = formatDuration(record.hours, record.minutes);
+                                const detailHours = isOnboardingOrOffboarding
+                                    ? (
+                                        record.type === 'offboarding'
+                                            ? Math.max(0, (calculateOffboardingAdjustment(attendanceData, formData) + 1) * 24)
+                                            : Math.max(0, 24 - timeToMinutesForDisplay(record.startTime, 24 * 60) / 60)
+                                    )
+                                    : ((record.hours || 0) + (record.minutes || 0) / 60);
+                                const durationText = formatDuration(detailHours, 0);
+                                const detailNote = getSpecialRecordDetailText(record, formData, attendanceData);
+                                const onboardingAttendanceLink = getOnboardingAttendanceLink(record, formData, attendanceData);
+                                const showReturnAttendanceAction = record.type === 'onboarding' && Boolean(returnAttendanceLink);
 
                                 if (isOnboardingOrOffboarding) {
                                     // 上户：显示到达时间（startTime）
@@ -2352,17 +2554,49 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                                             补齐{durationText}，因出勤天数超26天上限自动转换
                                                         </span>
                                                     )}
+                                                    {detailNote && (
+                                                        <span className="text-[10px] leading-snug text-gray-400 block mt-1 font-normal max-w-[210px]">
+                                                            {detailNote}
+                                                        </span>
+                                                    )}
+                                                    {onboardingAttendanceLink && (
+                                                        <button
+                                                            type="button"
+                                                            onClick={(event) => {
+                                                                event.stopPropagation();
+                                                                jumpToAttendanceMonth(
+                                                                    onboardingAttendanceLink.year,
+                                                                    onboardingAttendanceLink.month,
+                                                                    onboardingAttendanceLink.contractId,
+                                                                    onboardingAttendanceLink.signatureToken
+                                                                );
+                                                            }}
+                                                            className="mt-1.5 inline-flex items-center rounded-md border border-cyan-200 bg-cyan-50 px-2 py-1 text-[10px] font-semibold text-cyan-700 hover:bg-cyan-100"
+                                                        >
+                                                            查看上户考勤
+                                                        </button>
+                                                    )}
+                                                    {showReturnAttendanceAction && (
+                                                        <button
+                                                            type="button"
+                                                            onClick={(event) => {
+                                                                event.stopPropagation();
+                                                                goBackToReturnAttendance();
+                                                            }}
+                                                            className="mt-1.5 inline-flex items-center rounded-md border border-cyan-200 bg-cyan-50 px-2 py-1 text-[10px] font-semibold text-cyan-700 hover:bg-cyan-100"
+                                                        >
+                                                            <ArrowLeft className="w-3 h-3 mr-1" />
+                                                            {isCustomerMode ? '返回下户考勤签署' : '返回下户考勤'}
+                                                        </button>
+                                                    )}
                                                 </div>
                                             </div>
                                         </div>
-                                        {/* 上户/下户不显示时长 */}
-                                        {!isOnboardingOrOffboarding && (
-                                            <div className="text-right">
-                                                <div className="text-sm font-bold text-gray-900">
-                                                    {durationText}
-                                                </div>
+                                        <div className="text-right">
+                                            <div className="text-sm font-bold text-gray-900">
+                                                {durationText}
                                             </div>
-                                        )}
+                                        </div>
                                     </div>
                                 );
                             })}
@@ -2525,7 +2759,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                         )}
 
                                         {/* Share button for employees in confirmed status */}
-                                        {!isAdminView && formData.client_sign_url && formData.status === 'employee_confirmed' && (
+                                        {/* {!isAdminView && formData.client_sign_url && formData.status === 'employee_confirmed' && (
                                             <button
                                                 onClick={() => {
                                                     // 使用 sessionStorage 传递分享提示状态，避免 URL 参数被分享出去
@@ -2537,7 +2771,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                                 <Share2 className="w-5 h-5" />
                                                 前往签署页分享给客户
                                             </button>
-                                        )}
+                                        )} */}
                                     </>
                                 ) : (
                                     <div className="flex flex-col gap-4 w-full">
@@ -2557,7 +2791,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                                                             });
                                                             toast({ title: "修改成功", description: "状态已重置为待签署，员工可重新编辑。" });
                                                             // 刷新数据
-                                                            fetchData(selectedYear, selectedMonth);
+                                                            fetchData(selectedYear, selectedMonth, selectedContractId);
                                                         } catch (error) {
                                                             toast({ title: "修改失败", description: "服务器错误，请联系技术人员", variant: "destructive" });
                                                         } finally {

--- a/miniapp/config/env.js
+++ b/miniapp/config/env.js
@@ -1,5 +1,5 @@
 module.exports = {
   // local: local backend with mock login.
   // production: production backend for real-device preview/release.
-  current: 'production'
+  current: 'local'
 };

--- a/miniapp/pages/attendance-fill/index.js
+++ b/miniapp/pages/attendance-fill/index.js
@@ -349,7 +349,9 @@ Page({
     showHolidayHint: false,
     customerSignatureToken: '',
     sharePath: '',
-    shareTitle: '请确认月度考勤'
+    shareTitle: '请确认月度考勤',
+    returnAttendance: null,
+    showReturnAttendance: false
   },
 
   onLoad(options) {
@@ -579,6 +581,54 @@ Page({
     if (!this.data.canGoNext || !this.data.selectedYear || !this.data.selectedMonth) return;
     const date = new Date(this.data.selectedYear, this.data.selectedMonth, 1);
     this.loadForm(date.getFullYear(), date.getMonth() + 1);
+  },
+
+  goOnboardingAttendance(event) {
+    const { year, month, contractId, contractid } = event.currentTarget.dataset;
+    const targetYear = Number(year);
+    const targetMonth = Number(month);
+    if (!targetYear || !targetMonth) return;
+    const targetContractId = contractId || contractid || '';
+    const currentForm = this.data.form || {};
+    const returnAttendance = this.data.selectedYear && this.data.selectedMonth
+      ? {
+        year: this.data.selectedYear,
+        month: this.data.selectedMonth,
+        contractId: currentForm.contract_id || ''
+      }
+      : null;
+    if (targetContractId) {
+      this.setData({
+        form: {
+          ...this.data.form,
+          contract_id: targetContractId
+        }
+      });
+    }
+    this.setData({
+      returnAttendance,
+      showReturnAttendance: Boolean(returnAttendance)
+    });
+    this.loadForm(targetYear, targetMonth);
+  },
+
+  goReturnAttendance() {
+    const target = this.data.returnAttendance;
+    if (!target || !target.year || !target.month) return;
+    const targetContractId = target.contractId || '';
+    if (targetContractId) {
+      this.setData({
+        form: {
+          ...this.data.form,
+          contract_id: targetContractId
+        }
+      });
+    }
+    this.setData({
+      returnAttendance: null,
+      showReturnAttendance: false
+    });
+    this.loadForm(target.year, target.month);
   },
 
   buildModalState(record, editingDate, modalReadOnly = false, coveringRecord = null, holidays = this.data.holidays || {}) {

--- a/miniapp/pages/attendance-fill/index.wxml
+++ b/miniapp/pages/attendance-fill/index.wxml
@@ -78,6 +78,21 @@
         </view>
         <view class="detail-main">
           <view class="detail-time">{{item.timeLabel}}</view>
+          <view wx:if="{{item.detailNote}}" class="detail-note">{{item.detailNote}}</view>
+          <view
+            wx:if="{{item.onboardingAttendanceLink}}"
+            class="detail-link"
+            data-year="{{item.onboardingAttendanceLink.year}}"
+            data-month="{{item.onboardingAttendanceLink.month}}"
+            data-contract-id="{{item.onboardingAttendanceLink.contractId}}"
+            data-signature-token="{{item.onboardingAttendanceLink.signatureToken}}"
+            catchtap="goOnboardingAttendance"
+          >查看上户考勤</view>
+          <view
+            wx:if="{{showReturnAttendance && item.showReturnAttendanceAction}}"
+            class="detail-link"
+            catchtap="goReturnAttendance"
+          >返回下户考勤</view>
           <view wx:if="{{item.showDuration}}" class="detail-duration">{{item.durationText}}</view>
           <view wx:if="{{item.showAutoReason}}" class="detail-duration auto">{{item.autoReasonText}}</view>
         </view>

--- a/miniapp/pages/attendance-fill/index.wxss
+++ b/miniapp/pages/attendance-fill/index.wxss
@@ -386,6 +386,28 @@
   color: #334155;
 }
 
+.detail-note {
+  margin-top: 6rpx;
+  font-size: 20rpx;
+  line-height: 30rpx;
+  color: #94a3b8;
+  word-break: break-word;
+}
+
+.detail-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 8rpx;
+  padding: 8rpx 14rpx;
+  border: 1rpx solid #bae6fd;
+  border-radius: 10rpx;
+  background: #ecfeff;
+  color: #0891b2;
+  font-size: 21rpx;
+  font-weight: 800;
+}
+
 .detail-duration {
   margin-top: 6rpx;
   font-size: 24rpx;

--- a/miniapp/pages/attendance-sign/index.js
+++ b/miniapp/pages/attendance-sign/index.js
@@ -95,11 +95,30 @@ Page({
     sharePath: '',
     signaturePreview: '',
     hasSignature: false,
-    submitting: false
+    submitting: false,
+    returnAttendance: null,
+    showReturnAttendance: false
   },
 
   onLoad(options) {
-    this.setData({ token: options.token || '' });
+    const returnYear = options.returnYear ? Number(options.returnYear) : null;
+    const returnMonth = options.returnMonth ? Number(options.returnMonth) : null;
+    const returnAttendance = returnYear && returnMonth
+      ? {
+        year: returnYear,
+        month: returnMonth,
+        contractId: options.returnContractId || '',
+        signatureToken: options.returnSignatureToken || ''
+      }
+      : null;
+    this.setData({
+      token: options.token || '',
+      selectedYear: options.year ? Number(options.year) : null,
+      selectedMonth: options.month ? Number(options.month) : null,
+      contractId: options.contractId || '',
+      returnAttendance,
+      showReturnAttendance: Boolean(returnAttendance)
+    });
     this.loadForm();
   },
 
@@ -111,7 +130,11 @@ Page({
     wx.showLoading({ title: '加载中' });
     try {
       await api.ensureOpenid('customer');
-      const result = await api.attendanceSignDetail(this.data.token);
+      const result = await api.attendanceSignDetail(this.data.token, {
+        year: this.data.selectedYear,
+        month: this.data.selectedMonth,
+        contractId: this.data.contractId
+      });
       const form = result.attendance_form || {};
       const holidays = await this.loadHolidays(form.actual_year || form.year);
       this.applyForm(form, holidays, result.auth || null);
@@ -245,6 +268,44 @@ Page({
       showCancel: false,
       confirmText: '我知道了'
     });
+  },
+
+  goOnboardingAttendance(event) {
+    const { year, month, contractId, contractid, signatureToken, signaturetoken } = event.currentTarget.dataset;
+    const targetYear = Number(year);
+    const targetMonth = Number(month);
+    if (!targetYear || !targetMonth || !this.data.token) return;
+    const targetContractId = contractId || contractid || (this.data.form && this.data.form.contract_id);
+    const targetToken = signatureToken || signaturetoken || this.data.token;
+    const currentForm = this.data.form || {};
+    const currentYear = this.data.selectedYear || currentForm.actual_year || currentForm.year;
+    const currentMonth = this.data.selectedMonth || currentForm.actual_month || currentForm.month;
+    const currentContractId = this.data.contractId || currentForm.contract_id || '';
+    const params = [
+      `token=${encodeURIComponent(targetToken)}`,
+      `year=${targetYear}`,
+      `month=${targetMonth}`
+    ];
+    if (targetContractId) params.push(`contractId=${encodeURIComponent(targetContractId)}`);
+    if (currentYear && currentMonth) {
+      params.push(`returnYear=${encodeURIComponent(currentYear)}`);
+      params.push(`returnMonth=${encodeURIComponent(currentMonth)}`);
+      if (currentContractId) params.push(`returnContractId=${encodeURIComponent(currentContractId)}`);
+      params.push(`returnSignatureToken=${encodeURIComponent(this.data.token)}`);
+    }
+    wx.navigateTo({ url: `/pages/attendance-sign/index?${params.join('&')}` });
+  },
+
+  goReturnAttendance() {
+    const target = this.data.returnAttendance;
+    if (!target || !target.year || !target.month) return;
+    const params = [
+      `token=${encodeURIComponent(target.signatureToken || this.data.token)}`,
+      `year=${encodeURIComponent(target.year)}`,
+      `month=${encodeURIComponent(target.month)}`
+    ];
+    if (target.contractId) params.push(`contractId=${encodeURIComponent(target.contractId)}`);
+    wx.redirectTo({ url: `/pages/attendance-sign/index?${params.join('&')}` });
   },
 
   openAutoOvertimeInfo() {

--- a/miniapp/pages/attendance-sign/index.wxml
+++ b/miniapp/pages/attendance-sign/index.wxml
@@ -78,6 +78,21 @@
         </view>
         <view class="detail-main">
           <view class="detail-time">{{item.timeLabel}}</view>
+          <view wx:if="{{item.detailNote}}" class="detail-note">{{item.detailNote}}</view>
+          <view
+            wx:if="{{item.onboardingAttendanceLink}}"
+            class="detail-link"
+            data-year="{{item.onboardingAttendanceLink.year}}"
+            data-month="{{item.onboardingAttendanceLink.month}}"
+            data-contract-id="{{item.onboardingAttendanceLink.contractId}}"
+            data-signature-token="{{item.onboardingAttendanceLink.signatureToken}}"
+            catchtap="goOnboardingAttendance"
+          >查看上户考勤</view>
+          <view
+            wx:if="{{showReturnAttendance && item.showReturnAttendanceAction}}"
+            class="detail-link"
+            catchtap="goReturnAttendance"
+          >返回下户考勤签署</view>
           <view wx:if="{{item.showDuration}}" class="detail-duration">{{item.durationText}}</view>
           <view wx:if="{{item.showAutoReason}}" class="detail-duration auto">{{item.autoReasonText}}</view>
         </view>

--- a/miniapp/pages/attendance-sign/index.wxss
+++ b/miniapp/pages/attendance-sign/index.wxss
@@ -387,6 +387,28 @@
   word-break: break-word;
 }
 
+.detail-note {
+  margin-top: 6rpx;
+  font-size: 20rpx;
+  line-height: 30rpx;
+  color: #94a3b8;
+  word-break: break-word;
+}
+
+.detail-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 8rpx;
+  padding: 8rpx 14rpx;
+  border: 1rpx solid #bae6fd;
+  border-radius: 10rpx;
+  background: #ecfeff;
+  color: #0891b2;
+  font-size: 21rpx;
+  font-weight: 800;
+}
+
 .detail-duration {
   margin-top: 6rpx;
   font-size: 24rpx;

--- a/miniapp/utils/api.js
+++ b/miniapp/utils/api.js
@@ -84,6 +84,13 @@ async function ensureOpenid(role = '') {
   return openid;
 }
 
+function buildQuery(params = {}) {
+  return Object.keys(params)
+    .filter((key) => params[key] !== undefined && params[key] !== null && params[key] !== '')
+    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    .join('&');
+}
+
 module.exports = {
   getOpenid,
   ensureOpenid,
@@ -136,8 +143,9 @@ module.exports = {
   submitContractSign(token, data) {
     return request({ url: `/miniapp/contracts/sign/${token}`, method: 'POST', data });
   },
-  attendanceSignDetail(token) {
-    return request({ url: `/miniapp/attendance/sign/${token}` });
+  attendanceSignDetail(token, params = {}) {
+    const query = buildQuery(params);
+    return request({ url: `/miniapp/attendance/sign/${token}${query ? `?${query}` : ''}` });
   },
   verifyAttendanceSign(token, data) {
     return request({ url: `/miniapp/attendance/sign/${token}/auth`, method: 'POST', data });
@@ -152,10 +160,7 @@ module.exports = {
     return request({ url: `/miniapp/employee/attendance/${formId}` });
   },
   employeeAttendanceByToken(token, params = {}) {
-    const query = Object.keys(params)
-      .filter((key) => params[key] !== undefined && params[key] !== null && params[key] !== '')
-      .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
-      .join('&');
+    const query = buildQuery(params);
     return request({ url: `/miniapp/employee/attendance/by-token/${token}${query ? `?${query}` : ''}` });
   },
   updateEmployeeAttendance(formId, data) {

--- a/miniapp/utils/attendance.js
+++ b/miniapp/utils/attendance.js
@@ -210,11 +210,7 @@ function calculateTotalDuration(record = {}) {
 
 function formatDuration(hours, minutes = 0) {
   const totalHours = hours % 1 !== 0 ? Number(hours || 0) : Number(hours || 0) + Number(minutes || 0) / 60;
-  if (totalHours < 24) return `${Number(totalHours.toFixed(2))}小时`;
-  const days = Math.floor(totalHours / 24);
-  const remain = totalHours % 24;
-  if (remain <= 0.01) return `${days}天`;
-  return `${days}天${Number(remain.toFixed(2))}小时`;
+  return `${(totalHours / 24).toFixed(2)}天`;
 }
 
 function isFullDayRecord(record = {}) {
@@ -240,13 +236,131 @@ function formatRecordTimeLabel(record, actualStart, actualEnd) {
 
 function formatDays(value) {
   const total = Number(value || 0);
-  if (Math.abs(total) < 0.001) return '0';
-  const days = Math.floor(total);
-  const hours = (total - days) * 24;
-  if (hours <= 0.01) return `${days}`;
-  const hourText = Number(hours.toFixed(2));
-  if (days === 0) return `${hourText}小时`;
-  return `${days}天${hourText}小时`;
+  return `${total.toFixed(2)}天`;
+}
+
+function formatDayTextForNote(value) {
+  const total = Number(value || 0);
+  if (Math.abs(total - 1) < 0.005) return '1天';
+  return formatDays(total);
+}
+
+function normalizeAttendanceTimeText(time) {
+  if (!time) return '';
+  const minutes = timeToMinutes(time, NaN);
+  if (!Number.isFinite(minutes)) return String(time);
+  if (minutes >= 24 * 60) return '24:00';
+  return minutesToTime(minutes);
+}
+
+function getOnboardingReferenceForAttendance(form, attendanceData) {
+  const info = form?.onboarding_time_info || {};
+  if (info.onboarding_time) {
+    return {
+      date: info.onboarding_date || '',
+      time: info.onboarding_time,
+      contractId: info.contract_id || '',
+      signatureToken: info.customer_signature_token || ''
+    };
+  }
+
+  const normalized = normalizeAttendanceData(attendanceData || form?.form_data || {});
+  const onboardingRecord = (normalized.onboarding_records || []).find((record) => record.startTime);
+  if (!onboardingRecord) return null;
+  return {
+    date: onboardingRecord.date || '',
+    time: onboardingRecord.startTime,
+    contractId: onboardingRecord.contract_id || '',
+    signatureToken: onboardingRecord.customer_signature_token || ''
+  };
+}
+
+function getOnboardingTimeForAttendance(form, attendanceData) {
+  return getOnboardingReferenceForAttendance(form, attendanceData)?.time || '';
+}
+
+function getSpecialRecordDetailNote(record, form, attendanceData) {
+  if (record?.type === 'onboarding') {
+    const onboardingTime = normalizeAttendanceTimeText(record.startTime);
+    if (!onboardingTime) return '';
+    return `上户日 ${onboardingTime}~24:00 会在下户日当天计算考勤，本月不计算上户日当天考勤`;
+  }
+
+  if (record?.type === 'offboarding') {
+    const ref = getOnboardingReferenceForAttendance(form, attendanceData);
+    const onboardingTime = normalizeAttendanceTimeText(ref?.time);
+    const offboardingTime = normalizeAttendanceTimeText(record.endTime);
+    if (!onboardingTime || !offboardingTime) return '';
+
+    const onboardingMinutes = timeToMinutes(ref.time, 0);
+    const offboardingMinutes = timeToMinutes(record.endTime, 0);
+    const refDateText = formatMonthDay(ref.date);
+    const offboardingDateText = formatMonthDay(record.date);
+    const baseText = `${refDateText ? `${refDateText} ` : '上户日 '}${onboardingTime}~${offboardingDateText ? `${offboardingDateText} ` : '下户日 '}${onboardingTime} 算作1天`;
+    const deltaMinutes = offboardingMinutes - onboardingMinutes;
+
+    if (deltaMinutes > 0) {
+      return `${baseText}；下户日 ${onboardingTime}~${offboardingTime} 另计${formatDays(deltaMinutes / (24 * 60))}`;
+    }
+    if (deltaMinutes < 0) {
+      const combinedDays = ((24 * 60 - onboardingMinutes) + offboardingMinutes) / (24 * 60);
+      return `${baseText}；下户早于上户时间，合并计${formatDayTextForNote(combinedDays)}`;
+    }
+    return baseText;
+  }
+
+  return '';
+}
+
+function getOnboardingAttendanceLink(record, form, attendanceData) {
+  if (record?.type !== 'offboarding') return null;
+  const ref = getOnboardingReferenceForAttendance(form, attendanceData);
+  const date = parseDate(ref?.date);
+  if (!date) return null;
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    date: formatDate(date),
+    contractId: ref.contractId || '',
+    signatureToken: ref.signatureToken || '',
+    text: '查看上户考勤'
+  };
+}
+
+function calculateOnboardingDaysToExclude(attendanceData, form) {
+  const normalized = normalizeAttendanceData(attendanceData);
+  const cycleStart = parseDate(form?.cycle_start_date);
+  const cycleEnd = parseDate(form?.cycle_end_date);
+  if (!cycleStart || !cycleEnd) return 0;
+
+  const dates = new Set();
+  (normalized.onboarding_records || []).forEach((record) => {
+    const onboardingDate = parseDate(record.date);
+    if (onboardingDate && onboardingDate >= cycleStart && onboardingDate <= cycleEnd) {
+      dates.add(formatDate(onboardingDate));
+    }
+  });
+
+  const infoDate = parseDate(form?.onboarding_time_info?.onboarding_date);
+  if (infoDate && infoDate >= cycleStart && infoDate <= cycleEnd) {
+    dates.add(formatDate(infoDate));
+  }
+
+  return dates.size;
+}
+
+function calculateOffboardingAdjustment(attendanceData, form) {
+  const normalized = normalizeAttendanceData(attendanceData);
+  const offboardingRecord = (normalized.offboarding_records || []).find((record) => record.endTime);
+  const onboardingTime = getOnboardingTimeForAttendance(form, normalized);
+  const offboardingTime = offboardingRecord?.endTime;
+  if (!onboardingTime || !offboardingTime) return 0;
+
+  const onboardingMinutes = timeToMinutes(onboardingTime, NaN);
+  const offboardingMinutes = timeToMinutes(offboardingTime, NaN);
+  if (!Number.isFinite(onboardingMinutes) || !Number.isFinite(offboardingMinutes)) return 0;
+
+  return ((24 * 60 - onboardingMinutes) + offboardingMinutes) / (24 * 60) - 1;
 }
 
 function getHolidayInfo(date, holidays = {}) {
@@ -677,23 +791,10 @@ function calculateStats(attendanceData, monthDays, form, holidays = {}) {
     }
   });
 
-  let offboardingAdjustment = 0;
-  if ((normalized.offboarding_records || []).length > 0) {
-    const offboardingRecord = normalized.offboarding_records[0];
-    const offboardingTime = offboardingRecord.endTime;
-    const onboardingInfo = form?.onboarding_time_info || {};
-    const onboardingTime = onboardingInfo.onboarding_time
-      || ((normalized.onboarding_records || [])[0] || {}).startTime;
+  const onboardingDays = calculateOnboardingDaysToExclude(normalized, form);
+  const offboardingAdjustment = calculateOffboardingAdjustment(normalized, form);
 
-    if (onboardingTime && offboardingTime) {
-      const onboardingHours = timeToMinutes(onboardingTime, 0) / 60;
-      const offboardingHours = timeToMinutes(offboardingTime, 0) / 60;
-      offboardingAdjustment = (24 + offboardingHours) / 24 - 1;
-      if (!Number.isFinite(onboardingHours)) offboardingAdjustment = 0;
-    }
-  }
-
-  const totalWorkBeforeCap = validDays + offboardingAdjustment - totalLeaveDays;
+  const totalWorkBeforeCap = validDays - onboardingDays + offboardingAdjustment - totalLeaveDays;
   const recalculatedAuto = Math.max(0, totalWorkBeforeCap - 26 - manualNormalOvertimeDays);
   const totalWorkDays = Math.min(26, totalWorkBeforeCap);
   const totalOvertimeDays = totalManualOvertimeDays + (autoOvertimeDays > 0 ? recalculatedAuto : autoOvertimeDays);
@@ -790,13 +891,21 @@ function buildSpecialRecords(attendanceData, form) {
       const actualEnd = end > cycleEnd ? cycleEnd : end;
       const duration = calculateTotalDuration(record);
       const typeLabel = record.is_auto ? '自动补齐加班' : (TYPE_MAP[record.type]?.label || '考勤');
-      const durationText = formatDuration(duration.totalHours);
+      const durationHours = record.type === 'onboarding'
+        ? Math.max(0, 24 - timeToMinutes(record.startTime, 24 * 60) / 60)
+        : record.type === 'offboarding'
+          ? Math.max(0, (calculateOffboardingAdjustment(normalized, form) + 1) * 24)
+          : duration.totalHours;
+      const durationText = formatDuration(durationHours);
       return {
         ...record,
         typeLabel,
         timeLabel: formatRecordTimeLabel(record, actualStart, actualEnd),
+        detailNote: getSpecialRecordDetailNote(record, form, normalized),
+        onboardingAttendanceLink: getOnboardingAttendanceLink(record, form, normalized),
+        showReturnAttendanceAction: record.type === 'onboarding',
         durationText,
-        showDuration: record.type !== 'onboarding' && record.type !== 'offboarding' && !record.is_auto,
+        showDuration: !record.is_auto,
         showAutoReason: Boolean(record.is_auto),
         autoReasonText: record.is_auto ? `补齐${durationText}，因出勤超26天自动折算` : '',
         tone: TYPE_MAP[record.type]?.tone || 'normal',
@@ -866,7 +975,9 @@ function autoConvertOvertimeIfNeeded(attendanceData, form, monthDays, holidays =
     }
   });
 
-  const currentWorkDays = validDays - leaveDays - normalOvertimeDays;
+  const onboardingDays = calculateOnboardingDaysToExclude(data, form);
+  const offboardingAdjustment = calculateOffboardingAdjustment(data, form);
+  const currentWorkDays = validDays - onboardingDays + offboardingAdjustment - leaveDays - normalOvertimeDays;
   if (currentWorkDays <= 26) return { data, converted: false, overtimeDays: 0 };
 
   const exactDaysToConvert = currentWorkDays - 26;


### PR DESCRIPTION
- 使用合同终止日期作为考勤截止日期，不混淆合同结束日
- 上户月不计算上户当天考勤，下户月结合上户时间和下户时间折算出勤
- 考勤详情统一显示 xx.xx 天，并补充上下户计算说明
- Web 和小程序同步支持查看上户考勤
- 从上户月返回下户月的按钮移动到上户考勤详情内，保持操作位置一致
- 过滤未填写上下户时间时的默认详情展示