### PR TITLE
客户首页 如果 recent_contracts 为空但已经有待签考勤，首页会用待签考勤的 contract_id 兜底生成一张“服务合同”卡片，这样用户能从首页进入该合同详情，不会出现“上面有 5 月待签考勤，下面却暂无服务合同”的矛盾。

### DIFF
--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -1488,6 +1488,7 @@ def employee_overview():
                 "contracts": [_contract_summary(contract, include_employee_token=True) for contract in pending_contracts],
                 "attendance_forms": [_attendance_summary(form) for form in attendance_forms if form.status in ("draft", "employee_confirmed")],
             },
+            "recent_contracts": [_contract_summary(contract) for contract in contracts[:1]],
             "active_contracts": [_contract_summary(contract) for contract in active_contracts],
             "history_contracts": [_contract_summary(contract) for contract in history_contracts],
         }

--- a/miniapp/pages/employee-home/index.js
+++ b/miniapp/pages/employee-home/index.js
@@ -7,6 +7,7 @@ Page({
     pendingContracts: [],
     attendanceForms: [],
     activeContracts: [],
+    recentContracts: [],
     todoCount: 0,
     overviewLoaded: false
   },
@@ -40,11 +41,15 @@ Page({
         date_range: `${formatDate(item.cycle_start_date)} - ${formatDate(item.cycle_end_date)}`
       }));
       const activeContracts = (result.active_contracts || []).map(contractView);
+      const recentContracts = ((result.recent_contracts && result.recent_contracts.length)
+        ? result.recent_contracts
+        : result.active_contracts || []).slice(0, 1).map(contractView);
       this.setData({
         employee: result.employee || {},
         pendingContracts,
         attendanceForms,
         activeContracts,
+        recentContracts,
         todoCount: pendingContracts.length + attendanceForms.length,
         overviewLoaded: true
       });

--- a/miniapp/pages/employee-home/index.wxml
+++ b/miniapp/pages/employee-home/index.wxml
@@ -46,11 +46,11 @@
   </view>
 
   <view class="section-head">
-    <view class="section-title">履行中合同</view>
+    <view class="section-title">服务合同</view>
     <button class="link-btn" bindtap="goContracts">全部合同</button>
   </view>
 
-  <block wx:for="{{activeContracts}}" wx:key="id">
+  <block wx:for="{{recentContracts}}" wx:key="id">
     <view class="contract-card" data-id="{{item.id}}" bindtap="goContractDetail">
       <view class="contract-top">
         <view>
@@ -66,8 +66,8 @@
     </view>
   </block>
 
-  <view wx:if="{{overviewLoaded && activeContracts.length === 0}}" class="empty">
-    <view class="empty-title">暂无正在履行合同</view>
-    <view class="empty-desc">服务中的合同会显示在这里。</view>
+  <view wx:if="{{overviewLoaded && recentContracts.length === 0}}" class="empty">
+    <view class="empty-title">暂无服务合同</view>
+    <view class="empty-desc">最近服务合同会显示在这里。</view>
   </view>
 </view>

--- a/miniapp/pages/home/index.js
+++ b/miniapp/pages/home/index.js
@@ -91,6 +91,20 @@ function attendanceCardStats(stats = {}, item = {}) {
   };
 }
 
+function contractFallbackFromAttendance(attendance = {}) {
+  if (!attendance.contract_id) return null;
+  return contractView({
+    id: attendance.contract_id,
+    type_label: '服务合同',
+    employee_name: attendance.employee_name || '',
+    customer_name: attendance.customer_name || '',
+    start_date: attendance.cycle_start_date,
+    end_date: attendance.cycle_end_date,
+    status: 'active',
+    signing_status: 'SIGNED'
+  });
+}
+
 Page({
   data: {
     customer: {},
@@ -151,6 +165,10 @@ Page({
       const recentContracts = ((result.recent_contracts && result.recent_contracts.length)
         ? result.recent_contracts
         : result.active_contracts || []).slice(0, 1).map(contractView);
+      if (!recentContracts.length && pendingAttendance.length) {
+        const fallbackContract = contractFallbackFromAttendance(pendingAttendance[0]);
+        if (fallbackContract) recentContracts.push(fallbackContract);
+      }
       const upcomingContracts = activeContracts.filter((item) => item.status === 'pending');
       const servingContracts = activeContracts.filter((item) => item.status !== 'pending');
       this.setData({


### PR DESCRIPTION
员工首页
员工端也改为显示最近一个合同，不再只显示履行中合同：