### PR TITLE
feat: 增加小程序临时调试授权与员工考勤入口优化

### DIFF
--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -20,6 +20,7 @@ from backend.models import (
     CustomerWechatAccount,
     EmployeeWechatAccount,
     MiniappContractAccess,
+    MiniappDebugAccess,
     MiniappContractEvaluation,
     MiniappContractExitSummary,
     ServicePersonnel,
@@ -89,6 +90,30 @@ FALLBACK_HOLIDAYS = {
         "10-10": {"holiday": False, "name": "国庆节调休", "wage": 1},
     },
 }
+
+
+class _DebugEmployeeAccount:
+    def __init__(self, debug_access, employee):
+        self.id = debug_access.id
+        self.mini_openid = debug_access.debugger_openid
+        self.employee_id = debug_access.target_id
+        self.employee = employee
+        self.bind_method = "debug_access"
+        self.last_login_at = debug_access.last_used_at
+        self.debug_access = debug_access
+        self.is_debug_access = True
+
+
+class _DebugCustomerAccount:
+    def __init__(self, debug_access, customer):
+        self.id = debug_access.id
+        self.mini_openid = debug_access.debugger_openid
+        self.customer_id = debug_access.target_id
+        self.customer = customer
+        self.bind_method = "debug_access"
+        self.last_login_at = debug_access.last_used_at
+        self.debug_access = debug_access
+        self.is_debug_access = True
 
 
 def _now():
@@ -250,7 +275,18 @@ def miniapp_holidays(year):
         return jsonify({"success": True, "year": year, "holidays": cached, "cached": True})
 
     try:
-        response = requests.get(f"https://timor.tech/api/holiday/year/{year}", timeout=8)
+        response = requests.get(
+            f"https://timor.tech/api/holiday/year/{year}",
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/126.0.0.0 Safari/537.36"
+                ),
+                "Accept": "application/json,text/plain,*/*",
+            },
+            timeout=8,
+        )
         response.raise_for_status()
         payload = response.json()
         holidays = payload.get("holiday") if payload.get("code") == 0 else None
@@ -278,14 +314,54 @@ def _get_account(openid=None):
     openid = _normalize_openid(openid) or _get_openid_from_request()
     if not openid:
         return None
-    return CustomerWechatAccount.query.filter_by(mini_openid=openid).first()
+    account = CustomerWechatAccount.query.filter_by(mini_openid=openid).first()
+    if account:
+        return account
+
+    debug_access = _get_active_debug_access(openid, "customer")
+    if not debug_access:
+        return None
+    customer = Customer.query.get(debug_access.target_id)
+    if not customer:
+        return None
+    return _DebugCustomerAccount(debug_access, customer)
 
 
 def _get_employee_account(openid=None):
     openid = _normalize_openid(openid) or _get_openid_from_request()
     if not openid:
         return None
-    return EmployeeWechatAccount.query.filter_by(mini_openid=openid).first()
+    account = EmployeeWechatAccount.query.filter_by(mini_openid=openid).first()
+    if account:
+        return account
+
+    debug_access = _get_active_debug_access(openid, "employee")
+    if not debug_access:
+        return None
+    employee = ServicePersonnel.query.get(debug_access.target_id)
+    if not employee:
+        return None
+    return _DebugEmployeeAccount(debug_access, employee)
+
+
+def _get_active_debug_access(openid, role=None):
+    openid = _normalize_openid(openid)
+    if not openid:
+        return None
+    query = MiniappDebugAccess.query.filter(
+        MiniappDebugAccess.debugger_openid == openid,
+        MiniappDebugAccess.enabled.is_(True),
+        MiniappDebugAccess.expires_at > _now(),
+    )
+    if role:
+        query = query.filter(MiniappDebugAccess.role == role)
+    return query.order_by(MiniappDebugAccess.expires_at.desc(), MiniappDebugAccess.created_at.desc()).first()
+
+
+def _touch_debug_access(account):
+    debug_access = getattr(account, "debug_access", None)
+    if debug_access:
+        debug_access.last_used_at = _now()
 
 
 def _bind_customer_openid(customer_id, openid, unionid=None, phone_number=None, bind_method="contract_sign"):
@@ -1000,6 +1076,7 @@ def _ensure_employee_account():
     if not account:
         return None, (jsonify({"success": False, "error": "服务人员未绑定小程序身份"}), 401)
     account.last_login_at = _now()
+    _touch_debug_access(account)
     return account, None
 
 
@@ -1024,13 +1101,17 @@ def _default_attendance_cycle():
     return date(previous_month_end.year, previous_month_end.month, 1), previous_month_end
 
 
-def _get_or_create_employee_attendance_forms(employee):
-    cycle_start, cycle_end = _default_attendance_cycle()
+def _get_or_create_employee_attendance_forms(employee, year=None, month=None):
+    if year and month:
+        cycle_start = date(year, month, 1)
+        cycle_end = date(year, month, calendar.monthrange(year, month)[1])
+    else:
+        cycle_start, cycle_end = _default_attendance_cycle()
     contracts = [
         contract for contract in filter_contracts_for_cycle(employee.id, cycle_start, cycle_end)
         if _employee_has_signed_contract(contract)
     ]
-    if not contracts:
+    if not contracts and not (year and month):
         current_month_start = date.today().replace(day=1)
         current_month_end = date(
             current_month_start.year,
@@ -1119,16 +1200,35 @@ def miniapp_login():
             account.last_login_at = _now()
         if employee_account:
             employee_account.last_login_at = _now()
+        _touch_debug_access(account)
+        _touch_debug_access(employee_account)
         for access in contract_accesses:
             access.last_used_at = _now()
         if account or employee_account or contract_accesses:
             db.session.commit()
+
+        debug_accesses = [
+            getattr(item, "debug_access", None)
+            for item in (account, employee_account)
+            if getattr(item, "debug_access", None)
+        ]
 
         return jsonify(
             {
                 "success": True,
                 "openid": openid,
                 "unionid": session.get("unionid"),
+                "debug_mode": bool(debug_accesses),
+                "debug_access": {
+                    "id": str(debug_accesses[0].id),
+                    "role": debug_accesses[0].role,
+                    "target_type": debug_accesses[0].target_type,
+                    "target_id": str(debug_accesses[0].target_id),
+                    "expires_at": _iso(debug_accesses[0].expires_at),
+                    "reason": debug_accesses[0].reason or "",
+                }
+                if debug_accesses
+                else None,
                 "bound": bool(account),
                 "employee_bound": bool(employee_account),
                 "roles": roles,
@@ -1641,7 +1741,12 @@ def employee_attendance_forms():
     if error_response:
         return error_response
 
-    forms = _get_or_create_employee_attendance_forms(account.employee)
+    year = request.args.get("year", type=int)
+    month = request.args.get("month", type=int)
+    if (year and not month) or (month and not year):
+        return jsonify({"success": False, "error": "year/month 必须同时提供"}), 400
+
+    forms = _get_or_create_employee_attendance_forms(account.employee, year=year, month=month)
     db.session.commit()
     return jsonify({"success": True, "attendance_forms": [_attendance_summary(form) for form in forms]})
 

--- a/backend/api/wechat_admin_api.py
+++ b/backend/api/wechat_admin_api.py
@@ -1,9 +1,12 @@
 """
 微信关联管理API - 供管理员使用
 """
+from datetime import datetime, timedelta
+import uuid
+
 from flask import Blueprint, jsonify, request, current_app
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from backend.models import CustomerWechatAccount, EmployeeWechatAccount, db, ServicePersonnel, User
+from backend.models import Customer, CustomerWechatAccount, EmployeeWechatAccount, MiniappDebugAccess, db, ServicePersonnel, User
 from sqlalchemy import or_
 
 wechat_admin_bp = Blueprint('wechat_admin_api', __name__, url_prefix='/api/admin/wechat')
@@ -55,6 +58,32 @@ def _format_miniapp_openid_account(account, role):
         "last_login_at": _format_datetime(account.last_login_at),
         "created_at": _format_datetime(account.created_at),
         "updated_at": _format_datetime(account.updated_at),
+    }
+
+
+def _format_debug_access(access):
+    target = None
+    if access.target_type == "employee":
+        target = ServicePersonnel.query.get(access.target_id)
+    elif access.target_type == "customer":
+        target = Customer.query.get(access.target_id)
+
+    return {
+        "id": str(access.id),
+        "debugger_openid": access.debugger_openid,
+        "role": access.role,
+        "role_label": "员工" if access.role == "employee" else "客户",
+        "target_type": access.target_type,
+        "target_id": str(access.target_id),
+        "target_name": target.name if target else "",
+        "target_phone_number": getattr(target, "phone_number", "") if target else "",
+        "reason": access.reason or "",
+        "enabled": bool(access.enabled),
+        "is_active": bool(access.enabled and access.expires_at and access.expires_at > datetime.now(access.expires_at.tzinfo)),
+        "expires_at": _format_datetime(access.expires_at),
+        "last_used_at": _format_datetime(access.last_used_at),
+        "created_at": _format_datetime(access.created_at),
+        "disabled_at": _format_datetime(access.disabled_at),
     }
 
 
@@ -121,6 +150,126 @@ def get_miniapp_openid_links():
         })
     except Exception as e:
         current_app.logger.error(f"获取小程序 OpenID 绑定列表失败: {e}", exc_info=True)
+        return jsonify({"error": "服务器内部错误"}), 500
+
+
+@wechat_admin_bp.route('/miniapp-debug-access', methods=['GET'])
+@jwt_required()
+def get_miniapp_debug_access_list():
+    try:
+        _, error_response = _require_admin()
+        if error_response:
+            return error_response
+
+        debugger_openid = (request.args.get('debugger_openid') or '').strip()
+        target_id = (request.args.get('target_id') or '').strip()
+        role_filter = (request.args.get('role') or '').strip()
+        include_disabled = request.args.get('include_disabled', 'false').lower() == 'true'
+
+        query = MiniappDebugAccess.query
+        if debugger_openid:
+            query = query.filter(MiniappDebugAccess.debugger_openid == debugger_openid)
+        if target_id:
+            try:
+                query = query.filter(MiniappDebugAccess.target_id == uuid.UUID(target_id))
+            except ValueError:
+                return jsonify({"error": "target_id 格式不正确"}), 400
+        if role_filter in ("employee", "customer"):
+            query = query.filter(MiniappDebugAccess.role == role_filter)
+        if not include_disabled:
+            query = query.filter(MiniappDebugAccess.enabled.is_(True))
+
+        access_list = query.order_by(MiniappDebugAccess.created_at.desc()).limit(200).all()
+        return jsonify({"items": [_format_debug_access(access) for access in access_list]})
+    except Exception as e:
+        current_app.logger.error(f"获取小程序调试授权失败: {e}", exc_info=True)
+        return jsonify({"error": "服务器内部错误"}), 500
+
+
+@wechat_admin_bp.route('/miniapp-debug-access', methods=['POST'])
+@jwt_required()
+def create_miniapp_debug_access():
+    try:
+        current_user, error_response = _require_admin()
+        if error_response:
+            return error_response
+
+        data = request.get_json(silent=True) or {}
+        debugger_openid = (data.get("debugger_openid") or "").strip()
+        role = (data.get("role") or "").strip()
+        target_id = (data.get("target_id") or "").strip()
+        reason = (data.get("reason") or "").strip()
+        expires_in_minutes = int(data.get("expires_in_minutes") or 120)
+
+        if not debugger_openid:
+            return jsonify({"error": "调试人员 OpenID 不能为空"}), 400
+        if role not in ("employee", "customer"):
+            return jsonify({"error": "角色必须是 employee 或 customer"}), 400
+        if expires_in_minutes < 5 or expires_in_minutes > 24 * 60:
+            return jsonify({"error": "授权时长需在 5 分钟到 24 小时之间"}), 400
+
+        try:
+            target_uuid = uuid.UUID(target_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "目标ID格式不正确"}), 400
+
+        if role == "employee":
+            target = ServicePersonnel.query.get(target_uuid)
+            target_type = "employee"
+        else:
+            target = Customer.query.get(target_uuid)
+            target_type = "customer"
+        if not target:
+            return jsonify({"error": "目标人员不存在"}), 404
+
+        access = MiniappDebugAccess(
+            debugger_openid=debugger_openid,
+            role=role,
+            target_type=target_type,
+            target_id=target_uuid,
+            reason=reason,
+            expires_at=datetime.now() + timedelta(minutes=expires_in_minutes),
+            created_by=current_user.id,
+        )
+        db.session.add(access)
+        db.session.commit()
+
+        current_app.logger.info(
+            "管理员 %s 创建小程序临时调试授权 openid=%s role=%s target=%s:%s expires=%s",
+            current_user.username,
+            debugger_openid,
+            role,
+            target_type,
+            target_uuid,
+            access.expires_at,
+        )
+        return jsonify({"message": "临时调试授权已创建", "item": _format_debug_access(access)})
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"创建小程序调试授权失败: {e}", exc_info=True)
+        return jsonify({"error": "服务器内部错误"}), 500
+
+
+@wechat_admin_bp.route('/miniapp-debug-access/<access_id>', methods=['DELETE'])
+@jwt_required()
+def disable_miniapp_debug_access(access_id):
+    try:
+        current_user, error_response = _require_admin()
+        if error_response:
+            return error_response
+
+        access = MiniappDebugAccess.query.get(access_id)
+        if not access:
+            return jsonify({"error": "调试授权不存在"}), 404
+
+        access.enabled = False
+        access.disabled_at = datetime.now()
+        access.disabled_by = current_user.id
+        db.session.commit()
+        return jsonify({"message": "临时调试授权已停用", "item": _format_debug_access(access)})
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"停用小程序调试授权失败: {e}", exc_info=True)
         return jsonify({"error": "服务器内部错误"}), 500
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -965,6 +965,95 @@ class EmployeeWechatAccount(db.Model):
         return f"<EmployeeWechatAccount {self.mini_openid} -> {self.employee_id}>"
 
 
+class MiniappDebugAccess(db.Model):
+    __tablename__ = "miniapp_debug_access"
+    __table_args__ = (
+        db.Index("ix_miniapp_debug_access_openid", "debugger_openid"),
+        db.Index("ix_miniapp_debug_access_target", "target_type", "target_id"),
+        db.Index("ix_miniapp_debug_access_expires_at", "expires_at"),
+        {"comment": "小程序临时调试授权表"},
+    )
+
+    id = db.Column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="主键",
+    )
+    debugger_openid = db.Column(
+        db.String(100),
+        nullable=False,
+        comment="调试人员微信小程序openid",
+    )
+    role = db.Column(
+        db.String(20),
+        nullable=False,
+        comment="临时登录角色: employee/customer",
+    )
+    target_type = db.Column(
+        db.String(20),
+        nullable=False,
+        comment="目标类型: employee/customer",
+    )
+    target_id = db.Column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        comment="目标员工或客户ID",
+    )
+    reason = db.Column(db.Text, nullable=True, comment="授权原因")
+    enabled = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        server_default=db.text("true"),
+        comment="是否启用",
+    )
+    expires_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        comment="过期时间",
+    )
+    last_used_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=True,
+        comment="最近使用时间",
+    )
+    created_by = db.Column(
+        PG_UUID(as_uuid=True),
+        db.ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="创建管理员ID",
+    )
+    disabled_by = db.Column(
+        PG_UUID(as_uuid=True),
+        db.ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="停用管理员ID",
+    )
+    disabled_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=True,
+        comment="停用时间",
+    )
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        server_default=func.now(),
+        comment="创建时间",
+    )
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        comment="更新时间",
+    )
+
+    creator = db.relationship("User", foreign_keys=[created_by])
+    disabler = db.relationship("User", foreign_keys=[disabled_by])
+
+    def __repr__(self):
+        return f"<MiniappDebugAccess {self.debugger_openid} -> {self.target_type}:{self.target_id}>"
+
+
 class MiniappContractAccess(db.Model):
     __tablename__ = "miniapp_contract_access"
     __table_args__ = (

--- a/frontend/src/api/wechat.js
+++ b/frontend/src/api/wechat.js
@@ -28,3 +28,18 @@ export const deleteMiniappOpenidLink = async (role, accountId) => {
   const response = await api.delete(`/admin/wechat/miniapp-openids/${role}/${accountId}`);
   return response.data;
 };
+
+export const getMiniappDebugAccess = async (params) => {
+  const response = await api.get('/admin/wechat/miniapp-debug-access', { params });
+  return response.data;
+};
+
+export const createMiniappDebugAccess = async (data) => {
+  const response = await api.post('/admin/wechat/miniapp-debug-access', data);
+  return response.data;
+};
+
+export const deleteMiniappDebugAccess = async (accessId) => {
+  const response = await api.delete(`/admin/wechat/miniapp-debug-access/${accessId}`);
+  return response.data;
+};

--- a/frontend/src/pages/MiniappOpenidManagement.jsx
+++ b/frontend/src/pages/MiniappOpenidManagement.jsx
@@ -29,12 +29,19 @@ import {
 } from '@mui/material';
 import {
   DeleteOutline as DeleteOutlineIcon,
+  BugReport as BugReportIcon,
   Refresh as RefreshIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';
 import PageHeader from '../components/PageHeader';
 import { useToast } from '../components/ui/use-toast';
-import { deleteMiniappOpenidLink, getMiniappOpenidLinks } from '../api/wechat';
+import {
+  createMiniappDebugAccess,
+  deleteMiniappDebugAccess,
+  deleteMiniappOpenidLink,
+  getMiniappDebugAccess,
+  getMiniappOpenidLinks,
+} from '../api/wechat';
 
 const ROLE_LABELS = {
   customer: '客户',
@@ -86,6 +93,16 @@ export default function MiniappOpenidManagement() {
   const [error, setError] = useState('');
   const [selectedAccount, setSelectedAccount] = useState(null);
   const [deleting, setDeleting] = useState(false);
+  const [debugDialogOpen, setDebugDialogOpen] = useState(false);
+  const [debugAccessItems, setDebugAccessItems] = useState([]);
+  const [debugAccessLoading, setDebugAccessLoading] = useState(false);
+  const [debugForm, setDebugForm] = useState({
+    debugger_openid: '',
+    role: 'employee',
+    target_id: '',
+    expires_in_minutes: 120,
+    reason: '',
+  });
 
   const fetchItems = useCallback(async () => {
     setLoading(true);
@@ -154,12 +171,78 @@ export default function MiniappOpenidManagement() {
     }
   };
 
+  const fetchDebugAccess = useCallback(async (params = {}) => {
+    setDebugAccessLoading(true);
+    try {
+      const data = await getMiniappDebugAccess({ include_disabled: true, ...params });
+      setDebugAccessItems(data.items || []);
+    } catch (err) {
+      toast({
+        title: '获取调试授权失败',
+        description: err.response?.data?.error || '请稍后重试。',
+        variant: 'destructive',
+      });
+    } finally {
+      setDebugAccessLoading(false);
+    }
+  }, [toast]);
+
+  const openDebugDialog = (account = null) => {
+    setDebugForm({
+      debugger_openid: '',
+      role: account?.role || 'employee',
+      target_id: account?.subject_id || '',
+      expires_in_minutes: 120,
+      reason: '',
+    });
+    setDebugDialogOpen(true);
+    fetchDebugAccess(account?.subject_id ? { target_id: account.subject_id } : {});
+  };
+
+  const handleCreateDebugAccess = async () => {
+    try {
+      await createMiniappDebugAccess(debugForm);
+      toast({
+        title: '授权已创建',
+        description: '调试人员可用自己的微信临时登录目标身份，不影响真实绑定。',
+        variant: 'success',
+      });
+      fetchDebugAccess(debugForm.target_id ? { target_id: debugForm.target_id } : {});
+    } catch (err) {
+      toast({
+        title: '创建授权失败',
+        description: err.response?.data?.error || '请检查 OpenID 和目标ID。',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleDisableDebugAccess = async (accessId) => {
+    try {
+      await deleteMiniappDebugAccess(accessId);
+      toast({ title: '授权已停用', variant: 'success' });
+      fetchDebugAccess(debugForm.target_id ? { target_id: debugForm.target_id } : {});
+    } catch (err) {
+      toast({
+        title: '停用授权失败',
+        description: err.response?.data?.error || '请稍后重试。',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return (
     <Box sx={{ p: { xs: 2, sm: 4 }, minHeight: '100%' }}>
       <PageHeader
         title="微信小程序绑定"
         subtitle="查看客户与服务人员的小程序 OpenID 身份绑定，并处理误绑定解绑。"
       />
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+        <Button variant="outlined" startIcon={<BugReportIcon />} onClick={() => openDebugDialog()}>
+          临时调试授权
+        </Button>
+      </Box>
 
       <Card sx={{ mb: 4, boxShadow: '0 0 2rem 0 rgba(136,168,170,.08)', border: '1px solid rgba(0,0,0,.03)' }}>
         <CardContent sx={{ p: 3 }}>
@@ -243,15 +326,25 @@ export default function MiniappOpenidManagement() {
                     <TableCell>{formatDateTime(item.verified_at || item.created_at)}</TableCell>
                     <TableCell>{formatDateTime(item.last_login_at)}</TableCell>
                     <TableCell align="right">
-                      <Button
-                        color="error"
-                        size="small"
-                        variant="outlined"
-                        startIcon={<DeleteOutlineIcon />}
-                        onClick={() => setSelectedAccount(item)}
-                      >
-                        解绑
-                      </Button>
+                      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          startIcon={<BugReportIcon />}
+                          onClick={() => openDebugDialog(item)}
+                        >
+                          调试授权
+                        </Button>
+                        <Button
+                          color="error"
+                          size="small"
+                          variant="outlined"
+                          startIcon={<DeleteOutlineIcon />}
+                          onClick={() => setSelectedAccount(item)}
+                        >
+                          解绑
+                        </Button>
+                      </Box>
                     </TableCell>
                   </TableRow>
                 ))
@@ -291,6 +384,124 @@ export default function MiniappOpenidManagement() {
           <Button onClick={() => setSelectedAccount(null)} disabled={deleting}>取消</Button>
           <Button color="error" variant="contained" onClick={handleConfirmDelete} disabled={deleting}>
             {deleting ? '解绑中...' : '确认解绑'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={debugDialogOpen} onClose={() => setDebugDialogOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>临时调试授权</DialogTitle>
+        <DialogContent>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            临时授权不会修改真实员工/客户的正式 OpenID 绑定，到期或停用后自动失效。
+          </Alert>
+          <Grid container spacing={2} sx={{ mt: 0 }}>
+            <Grid item xs={12} md={6}>
+              <TextField
+                fullWidth
+                size="small"
+                label="调试人员 OpenID"
+                value={debugForm.debugger_openid}
+                onChange={(event) => setDebugForm((prev) => ({ ...prev, debugger_openid: event.target.value.trim() }))}
+              />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <FormControl fullWidth size="small">
+                <InputLabel>角色</InputLabel>
+                <Select
+                  value={debugForm.role}
+                  label="角色"
+                  onChange={(event) => setDebugForm((prev) => ({ ...prev, role: event.target.value }))}
+                >
+                  <MenuItem value="employee">员工</MenuItem>
+                  <MenuItem value="customer">客户</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="有效分钟"
+                value={debugForm.expires_in_minutes}
+                onChange={(event) => setDebugForm((prev) => ({ ...prev, expires_in_minutes: Number(event.target.value) }))}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                size="small"
+                label="目标员工/客户ID"
+                value={debugForm.target_id}
+                onChange={(event) => setDebugForm((prev) => ({ ...prev, target_id: event.target.value.trim() }))}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                size="small"
+                label="授权原因"
+                value={debugForm.reason}
+                onChange={(event) => setDebugForm((prev) => ({ ...prev, reason: event.target.value }))}
+              />
+            </Grid>
+          </Grid>
+
+          <Box sx={{ mt: 3, mb: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>最近调试授权</Typography>
+            <Button size="small" onClick={() => fetchDebugAccess(debugForm.target_id ? { target_id: debugForm.target_id } : {})}>
+              刷新
+            </Button>
+          </Box>
+          <TableContainer sx={{ border: '1px solid rgba(0,0,0,.08)', borderRadius: 1 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>调试 OpenID</TableCell>
+                  <TableCell>目标</TableCell>
+                  <TableCell>状态</TableCell>
+                  <TableCell>过期时间</TableCell>
+                  <TableCell align="right">操作</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {debugAccessLoading ? (
+                  <TableRow><TableCell colSpan={5} align="center"><CircularProgress size={20} /></TableCell></TableRow>
+                ) : debugAccessItems.length ? (
+                  debugAccessItems.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell sx={{ maxWidth: 220 }}>
+                        <Tooltip title={item.debugger_openid || ''}>
+                          <Typography variant="caption" sx={{ fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'block' }}>
+                            {item.debugger_openid}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>{item.role_label} · {item.target_name || item.target_id}</TableCell>
+                      <TableCell>
+                        <Chip size="small" label={item.is_active ? '生效中' : '已失效'} color={item.is_active ? 'success' : 'default'} />
+                      </TableCell>
+                      <TableCell>{formatDateTime(item.expires_at)}</TableCell>
+                      <TableCell align="right">
+                        {item.enabled && (
+                          <Button size="small" color="error" onClick={() => handleDisableDebugAccess(item.id)}>
+                            停用
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow><TableCell colSpan={5} align="center">暂无调试授权</TableCell></TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDebugDialogOpen(false)}>关闭</Button>
+          <Button variant="contained" startIcon={<BugReportIcon />} onClick={handleCreateDebugAccess}>
+            创建授权
           </Button>
         </DialogActions>
       </Dialog>

--- a/migrations/versions/e1f2a3b4c5d6_add_miniapp_debug_access.py
+++ b/migrations/versions/e1f2a3b4c5d6_add_miniapp_debug_access.py
@@ -1,0 +1,60 @@
+"""add miniapp debug access
+
+Revision ID: e1f2a3b4c5d6
+Revises: d9e0f1a2b3c4
+Create Date: 2026-06-23 10:20:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "e1f2a3b4c5d6"
+down_revision = "d9e0f1a2b3c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("miniapp_debug_access"):
+        return
+
+    op.create_table(
+        "miniapp_debug_access",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False, comment="主键"),
+        sa.Column("debugger_openid", sa.String(length=100), nullable=False, comment="调试人员微信小程序openid"),
+        sa.Column("role", sa.String(length=20), nullable=False, comment="临时登录角色: employee/customer"),
+        sa.Column("target_type", sa.String(length=20), nullable=False, comment="目标类型: employee/customer"),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False, comment="目标员工或客户ID"),
+        sa.Column("reason", sa.Text(), nullable=True, comment="授权原因"),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False, comment="是否启用"),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False, comment="过期时间"),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True, comment="最近使用时间"),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True, comment="创建管理员ID"),
+        sa.Column("disabled_by", postgresql.UUID(as_uuid=True), nullable=True, comment="停用管理员ID"),
+        sa.Column("disabled_at", sa.DateTime(timezone=True), nullable=True, comment="停用时间"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True, comment="创建时间"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True, comment="更新时间"),
+        sa.ForeignKeyConstraint(["created_by"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["disabled_by"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        comment="小程序临时调试授权表",
+    )
+    op.create_index("ix_miniapp_debug_access_openid", "miniapp_debug_access", ["debugger_openid"], unique=False)
+    op.create_index("ix_miniapp_debug_access_target", "miniapp_debug_access", ["target_type", "target_id"], unique=False)
+    op.create_index("ix_miniapp_debug_access_expires_at", "miniapp_debug_access", ["expires_at"], unique=False)
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("miniapp_debug_access"):
+        return
+
+    op.drop_index("ix_miniapp_debug_access_expires_at", table_name="miniapp_debug_access")
+    op.drop_index("ix_miniapp_debug_access_target", table_name="miniapp_debug_access")
+    op.drop_index("ix_miniapp_debug_access_openid", table_name="miniapp_debug_access")
+    op.drop_table("miniapp_debug_access")

--- a/miniapp/pages/attendance-fill/index.js
+++ b/miniapp/pages/attendance-fill/index.js
@@ -263,9 +263,9 @@ Page({
       workDaysText: '0',
       leaveDaysText: '0',
       overtimeDaysText: '0',
-      workDaysHoursText: '0天0小时',
-      leaveDaysHoursText: '0天0小时',
-      overtimeDaysHoursText: '0天0小时',
+      workDaysHoursText: '',
+      leaveDaysHoursText: '',
+      overtimeDaysHoursText: '',
       holidayOvertimeDaysText: '0'
     },
     showHolidayOvertimeStat: false,

--- a/miniapp/pages/attendance-fill/index.wxml
+++ b/miniapp/pages/attendance-fill/index.wxml
@@ -16,17 +16,17 @@
     <view class="stats-panel">
       <view class="stat-col">
         <view class="stat-num">{{stats.workDaysText}}</view>
-        <view class="stat-hours">{{stats.workDaysHoursText}}</view>
+        <view wx:if="{{stats.workDaysHoursText}}" class="stat-hours">{{stats.workDaysHoursText}}</view>
         <view class="stat-label">出勤(天)</view>
       </view>
       <view class="stat-col">
         <view class="stat-num orange">{{stats.leaveDaysText}}</view>
-        <view class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
+        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
         <view class="stat-label">请假/休假</view>
       </view>
       <view class="stat-col">
         <view class="stat-num green">{{stats.overtimeDaysText}}</view>
-        <view class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
+        <view wx:if="{{stats.overtimeDaysHoursText}}" class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
         <view class="stat-label">加班(天)</view>
         
       </view>

--- a/miniapp/pages/attendance-sign/index.js
+++ b/miniapp/pages/attendance-sign/index.js
@@ -49,9 +49,9 @@ function buildEmptyStats() {
     workDaysText: '0',
     leaveDaysText: '0',
     overtimeDaysText: '0',
-    workDaysHoursText: '0天0小时',
-    leaveDaysHoursText: '0天0小时',
-    overtimeDaysHoursText: '0天0小时',
+    workDaysHoursText: '',
+    leaveDaysHoursText: '',
+    overtimeDaysHoursText: '',
     holidayOvertimeDaysText: '0',
     autoOvertimeDaysText: '0'
   };

--- a/miniapp/pages/attendance-sign/index.wxml
+++ b/miniapp/pages/attendance-sign/index.wxml
@@ -15,17 +15,17 @@
     <view class="stats-panel">
       <view class="stat-col">
         <view class="stat-num">{{stats.workDaysText}}</view>
-        <view class="stat-hours">{{stats.workDaysHoursText}}</view>
+        <view wx:if="{{stats.workDaysHoursText}}" class="stat-hours">{{stats.workDaysHoursText}}</view>
         <view class="stat-label">出勤(天)</view>
       </view>
       <view class="stat-col">
         <view class="stat-num orange">{{stats.leaveDaysText}}</view>
-        <view class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
+        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
         <view class="stat-label">请假/休假</view>
       </view>
       <view class="stat-col">
         <view class="stat-num green">{{stats.overtimeDaysText}}</view>
-        <view class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
+        <view wx:if="{{stats.overtimeDaysHoursText}}" class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
         <view class="stat-label">加班(天)</view>
         <view wx:if="{{showHolidayOvertimeStat}}" class="stat-sub">含法定 {{stats.holidayOvertimeDaysText}}</view>
       </view>

--- a/miniapp/pages/employee-home/index.js
+++ b/miniapp/pages/employee-home/index.js
@@ -79,6 +79,31 @@ Page({
     if (id) wx.navigateTo({ url: `/pages/attendance-fill/index?id=${id}` });
   },
 
+  async goAttendanceEntry() {
+    wx.showLoading({ title: '加载考勤' });
+    try {
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = now.getMonth() + 1;
+      const result = await api.employeeAttendanceList({ year, month });
+      const forms = result.attendance_forms || [];
+      if (!forms.length) {
+        wx.showToast({ title: '本月暂无可填写考勤', icon: 'none' });
+        return;
+      }
+      const form = forms.find((item) => item.status === 'draft')
+        || forms.find((item) => item.status === 'employee_confirmed')
+        || forms[0];
+      if (form && form.id) {
+        wx.navigateTo({ url: `/pages/attendance-fill/index?id=${form.id}` });
+      }
+    } catch (error) {
+      wx.showToast({ title: error.message || '加载失败', icon: 'none' });
+    } finally {
+      wx.hideLoading();
+    }
+  },
+
   goContractDetail(event) {
     const id = event.currentTarget.dataset.id;
     if (id) wx.navigateTo({ url: `/pages/contract-detail/index?id=${id}&role=employee` });

--- a/miniapp/pages/employee-home/index.wxml
+++ b/miniapp/pages/employee-home/index.wxml
@@ -45,7 +45,28 @@
     <view class="empty-desc">待签合同和待填写考勤会显示在这里。</view>
   </view>
 
-  <view class="section-head">
+  <view wx:if="{{overviewLoaded && attendanceForms.length === 0}}" class="quick-entry-card" bindtap="goAttendanceEntry">
+    <view class="quick-entry-main">
+      <view class="quick-entry-icon">
+        <view class="calendar-icon">
+          <view class="calendar-icon-head"></view>
+          <view class="calendar-icon-grid">
+            <view></view>
+            <view></view>
+            <view></view>
+            <view></view>
+          </view>
+        </view>
+      </view>
+      <view class="quick-entry-content">
+        <view class="quick-entry-title">填写月度考勤</view>
+        <view class="quick-entry-desc">提前下户或需要补填时，可从这里进入考勤表。</view>
+      </view>
+    </view>
+    <view class="quick-entry-arrow">›</view>
+  </view>
+
+  <view class="section-head contract-section-head">
     <view class="section-title">服务合同</view>
     <button class="link-btn" bindtap="goContracts">全部合同</button>
   </view>

--- a/miniapp/pages/employee-home/index.wxss
+++ b/miniapp/pages/employee-home/index.wxss
@@ -21,6 +21,24 @@
   font-weight: 800;
 }
 
+.contract-section-head {
+  position: relative;
+}
+
+.contract-section-head .link-btn {
+  position: absolute;
+  right: 0;
+  bottom: 18rpx;
+  margin-top: 0;
+  width: 150rpx;
+  height: 48rpx;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  text-align: right;
+  line-height: 48rpx;
+}
+
 .action-card,
 .contract-card {
   margin-bottom: 18rpx;
@@ -103,6 +121,111 @@
 .todo-badge.teal {
   background: #ecfdfa;
   color: #0f766e;
+}
+
+.quick-entry-card {
+  margin: 18rpx 0 28rpx;
+  padding: 24rpx;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18rpx;
+  border-radius: 16rpx;
+  background: #f0fdfa;
+  border: 1rpx solid #99f6e4;
+}
+
+.quick-entry-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 18rpx;
+}
+
+.quick-entry-icon {
+  width: 64rpx;
+  height: 64rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 14rpx;
+  background: #0f9f8f;
+  overflow: hidden;
+}
+
+.calendar-icon {
+  position: relative;
+  width: 38rpx;
+  height: 42rpx;
+  border: 4rpx solid #fff;
+  border-radius: 7rpx;
+  box-sizing: border-box;
+}
+
+.calendar-icon::before,
+.calendar-icon::after {
+  content: "";
+  position: absolute;
+  top: -10rpx;
+  width: 6rpx;
+  height: 14rpx;
+  border-radius: 999rpx;
+  background: #fff;
+}
+
+.calendar-icon::before {
+  left: 7rpx;
+}
+
+.calendar-icon::after {
+  right: 7rpx;
+}
+
+.calendar-icon-head {
+  height: 10rpx;
+  border-bottom: 4rpx solid #fff;
+}
+
+.calendar-icon-grid {
+  padding: 6rpx 5rpx 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4rpx;
+}
+
+.calendar-icon-grid view {
+  width: 6rpx;
+  height: 6rpx;
+  border-radius: 2rpx;
+  background: #fff;
+}
+
+.quick-entry-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.quick-entry-title {
+  font-size: 27rpx;
+  line-height: 36rpx;
+  font-weight: 900;
+  color: #0f172a;
+}
+
+.quick-entry-desc {
+  margin-top: 6rpx;
+  font-size: 23rpx;
+  line-height: 32rpx;
+  color: #0f766e;
+}
+
+.quick-entry-arrow {
+  flex-shrink: 0;
+  color: #0f766e;
+  font-size: 38rpx;
+  font-weight: 700;
 }
 
 .contract-top {

--- a/miniapp/utils/api.js
+++ b/miniapp/utils/api.js
@@ -153,8 +153,9 @@ module.exports = {
   submitAttendanceSign(token, data) {
     return request({ url: `/miniapp/attendance/sign/${token}`, method: 'POST', data });
   },
-  employeeAttendanceList() {
-    return request({ url: '/miniapp/employee/attendance' });
+  employeeAttendanceList(params = {}) {
+    const query = buildQuery(params);
+    return request({ url: `/miniapp/employee/attendance${query ? `?${query}` : ''}` });
   },
   employeeAttendanceDetail(formId) {
     return request({ url: `/miniapp/employee/attendance/${formId}` });

--- a/miniapp/utils/attendance.js
+++ b/miniapp/utils/attendance.js
@@ -245,8 +245,9 @@ function formatDaysHours(value) {
   const hours = (total - days) * 24;
   const roundedHours = Math.round(hours * 10) / 10;
   if (roundedHours >= 24) {
-    return `${days + 1}天0小时`;
+    return `${days + 1}天`;
   }
+  if (roundedHours <= 0) return days > 0 ? `${days}天` : '';
   const hourText = Math.abs(roundedHours - Math.round(roundedHours)) < 0.05
     ? String(Math.round(roundedHours))
     : roundedHours.toFixed(1).replace(/\.0$/, '');
@@ -258,6 +259,7 @@ function formatHoursText(hours) {
   const total = Math.max(0, Number(hours || 0));
   const days = Math.floor(total / 24);
   const remainder = Math.round((total - days * 24) * 10) / 10;
+  if (remainder <= 0) return days > 0 ? `${days}天` : '';
   const hourText = Math.abs(remainder - Math.round(remainder)) < 0.05
     ? String(Math.round(remainder))
     : remainder.toFixed(1).replace(/\.0$/, '');


### PR DESCRIPTION
- 新增小程序临时调试授权表，支持管理员为调试 OpenID 临时授权员工或客户身份
- 小程序登录后端支持识别有效调试授权，不覆盖真实 OpenID 绑定
- 后台微信小程序绑定页面增加临时调试授权创建、查看和停用功能
- 小程序员工首页增加当月考勤主动填写入口，支持提前下户场景
- 优化员工首页考勤入口图标与“全部合同”按钮对齐
- 修复考勤填写页入口参数丢失导致日历为空的问题
- 优化考勤天数小时展示，隐藏 0 小时
- 节假日接口请求增加浏览器请求头，避免第三方接口 403