### PR TITLE
feat:

### DIFF
--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -6,7 +6,7 @@ import time
 import uuid
 
 import requests
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, Response, current_app, jsonify, request
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import flag_modified
@@ -90,6 +90,24 @@ FALLBACK_HOLIDAYS = {
         "10-10": {"holiday": False, "name": "国庆节调休", "wage": 1},
     },
 }
+
+MINIAPP_ICON_SVGS = {
+    "contract_sign": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 14.7V19a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-4.3"/><path d="M14.5 3.5a2.1 2.1 0 0 1 3 3L9.6 14.4 5.5 15.5l1.1-4.1 7.9-7.9Z"/><path d="m13.4 4.6 3 3"/><path d="M7 19c2-2 3.7-2 5 0 1.2 1.7 3 1.6 5.5-.4"/></svg>""",
+    "attendance_fill": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="18" rx="3"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/><path d="M16 18h.01"/></svg>""",
+    "evaluation": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5 14.7 9l6 .9-4.4 4.2 1 6-5.3-2.8-5.3 2.8 1-6L3.3 9.9l6-.9L12 3.5Z"/><path d="M4 21h16"/></svg>""",
+}
+
+
+@miniapp_bp.route("/icons/<string:icon_key>.svg", methods=["GET"])
+def miniapp_icon(icon_key):
+    svg = MINIAPP_ICON_SVGS.get(icon_key)
+    if not svg:
+        return jsonify({"success": False, "error": "图标不存在"}), 404
+
+    response = Response(svg, mimetype="image/svg+xml")
+    response.headers["Cache-Control"] = "public, max-age=86400"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
 
 
 class _DebugEmployeeAccount:

--- a/miniapp/pages/employee-home/index.js
+++ b/miniapp/pages/employee-home/index.js
@@ -9,7 +9,11 @@ Page({
     activeContracts: [],
     recentContracts: [],
     todoCount: 0,
-    overviewLoaded: false
+    overviewLoaded: false,
+    icons: {
+      contractSign: api.miniappIconUrl('contract_sign'),
+      attendanceFill: api.miniappIconUrl('attendance_fill')
+    }
   },
 
   onShow() {

--- a/miniapp/pages/employee-home/index.wxml
+++ b/miniapp/pages/employee-home/index.wxml
@@ -17,7 +17,9 @@
   <block wx:for="{{pendingContracts}}" wx:key="id">
     <view class="action-card" data-token="{{item.employee_signing_token}}" bindtap="goContractSign">
       <view class="action-main">
-        <view class="action-icon">签</view>
+        <view class="action-icon contract-sign-icon">
+          <image class="action-icon-img" src="{{icons.contractSign}}" mode="aspectFit" />
+        </view>
         <view class="action-content">
           <view class="action-title">{{item.type_label}}待签署</view>
           <view class="action-desc">{{item.customer_name || '客户'}} · {{item.start_date_text}} 开始</view>
@@ -30,7 +32,9 @@
   <block wx:for="{{attendanceForms}}" wx:key="id">
     <view class="action-card" data-id="{{item.id}}" bindtap="goAttendanceFill">
       <view class="action-main">
-        <view class="action-icon">勤</view>
+        <view class="action-icon attendance-icon">
+          <image class="action-icon-img" src="{{icons.attendanceFill}}" mode="aspectFit" />
+        </view>
         <view class="action-content">
           <view class="action-title">{{item.month || '-'}} 月考勤{{item.status === 'employee_confirmed' ? '待客户确认' : '待填写'}}</view>
           <view class="action-desc">{{item.customer_name || '客户'}} · {{item.date_range}}</view>
@@ -48,15 +52,7 @@
   <view wx:if="{{overviewLoaded && attendanceForms.length === 0}}" class="quick-entry-card" bindtap="goAttendanceEntry">
     <view class="quick-entry-main">
       <view class="quick-entry-icon">
-        <view class="calendar-icon">
-          <view class="calendar-icon-head"></view>
-          <view class="calendar-icon-grid">
-            <view></view>
-            <view></view>
-            <view></view>
-            <view></view>
-          </view>
-        </view>
+        <image class="quick-entry-icon-img" src="{{icons.attendanceFill}}" mode="aspectFit" />
       </view>
       <view class="quick-entry-content">
         <view class="quick-entry-title">填写月度考勤</view>

--- a/miniapp/pages/employee-home/index.wxss
+++ b/miniapp/pages/employee-home/index.wxss
@@ -72,10 +72,18 @@
   justify-content: center;
   flex-shrink: 0;
   border-radius: 12rpx;
-  background: #ecfdfa;
-  color: #0f9f8f;
-  font-size: 28rpx;
-  font-weight: 900;
+  background: #0f9f8f;
+  overflow: hidden;
+}
+
+.contract-sign-icon,
+.attendance-icon {
+  background: #0f9f8f;
+}
+
+.action-icon-img {
+  width: 46rpx;
+  height: 46rpx;
 }
 
 .action-content {
@@ -155,51 +163,9 @@
   overflow: hidden;
 }
 
-.calendar-icon {
-  position: relative;
-  width: 38rpx;
+.quick-entry-icon-img {
+  width: 42rpx;
   height: 42rpx;
-  border: 4rpx solid #fff;
-  border-radius: 7rpx;
-  box-sizing: border-box;
-}
-
-.calendar-icon::before,
-.calendar-icon::after {
-  content: "";
-  position: absolute;
-  top: -10rpx;
-  width: 6rpx;
-  height: 14rpx;
-  border-radius: 999rpx;
-  background: #fff;
-}
-
-.calendar-icon::before {
-  left: 7rpx;
-}
-
-.calendar-icon::after {
-  right: 7rpx;
-}
-
-.calendar-icon-head {
-  height: 10rpx;
-  border-bottom: 4rpx solid #fff;
-}
-
-.calendar-icon-grid {
-  padding: 6rpx 5rpx 0;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 4rpx;
-}
-
-.calendar-icon-grid view {
-  width: 6rpx;
-  height: 6rpx;
-  border-radius: 2rpx;
-  background: #fff;
 }
 
 .quick-entry-content {

--- a/miniapp/pages/home/index.js
+++ b/miniapp/pages/home/index.js
@@ -117,7 +117,11 @@ Page({
     upcomingContracts: [],
     serviceContractCount: 0,
     todoCount: 0,
-    overviewLoaded: false
+    overviewLoaded: false,
+    icons: {
+      contractSign: api.miniappIconUrl('contract_sign'),
+      evaluation: api.miniappIconUrl('evaluation')
+    }
   },
 
   onShow() {

--- a/miniapp/pages/home/index.wxml
+++ b/miniapp/pages/home/index.wxml
@@ -17,7 +17,9 @@
   <block wx:for="{{pendingContracts}}" wx:key="id">
     <view class="action-card" data-token="{{item.customer_signing_token}}" bindtap="goContractSign">
       <view class="action-main">
-        <view class="action-icon">签</view>
+        <view class="action-icon contract-sign-icon">
+          <image class="action-icon-img" src="{{icons.contractSign}}" mode="aspectFit" />
+        </view>
         <view class="action-content">
           <view class="action-title">{{item.type_label}}待签署</view>
           <view class="action-desc">{{item.employee_name || '服务人员'}} · {{item.start_date_text}} 开始</view>
@@ -65,7 +67,9 @@
   <block wx:for="{{pendingEvaluations}}" wx:key="id">
     <view class="action-card" data-id="{{item.id}}" bindtap="goEvaluation">
       <view class="action-main">
-        <view class="action-icon eval">评</view>
+        <view class="action-icon eval-icon">
+          <image class="action-icon-img" src="{{icons.evaluation}}" mode="aspectFit" />
+        </view>
         <view class="action-content">
           <view class="action-title">{{item.type_label || '服务合同'}}待评价</view>
           <view class="action-desc">{{item.employee_name || '服务人员'}} · {{item.date_range}}</view>

--- a/miniapp/pages/home/index.wxss
+++ b/miniapp/pages/home/index.wxss
@@ -71,15 +71,21 @@
   justify-content: center;
   flex-shrink: 0;
   border-radius: 12rpx;
-  background: #ecfdfa;
-  color: #0f9f8f;
-  font-size: 28rpx;
-  font-weight: 900;
+  background: #0f9f8f;
+  overflow: hidden;
 }
 
-.action-icon.eval {
-  background: #fff7ed;
-  color: #b45309;
+.contract-sign-icon {
+  background: #0f9f8f;
+}
+
+.eval-icon {
+  background: #13a89a;
+}
+
+.action-icon-img {
+  width: 46rpx;
+  height: 46rpx;
 }
 
 .action-content {

--- a/miniapp/utils/api.js
+++ b/miniapp/utils/api.js
@@ -60,6 +60,10 @@ function assetUrl(path) {
   return `${apiOrigin}${path.startsWith('/') ? path : `/${path}`}`;
 }
 
+function miniappIconUrl(key) {
+  return `${apiBaseUrl}/miniapp/icons/${encodeURIComponent(key)}.svg`;
+}
+
 async function ensureOpenid(role = '') {
   const existing = getOpenid();
   if (existing) return existing;
@@ -95,6 +99,7 @@ module.exports = {
   getOpenid,
   ensureOpenid,
   assetUrl,
+  miniappIconUrl,
   login(data) {
     return request({ url: '/miniapp/auth/login', method: 'POST', data });
   },


### PR DESCRIPTION
后端新增图标接口：/api/miniapp/icons/<icon>.svgcontract_sign
attendance_fill
evaluation

小程序新增 miniappIconUrl()，按当前环境自动生成本地/生产图标地址。
客户端首页的“待签署合同 / 待评价”改为后端 SVG 图标。
员工端首页的“待签署合同 / 考勤填写 / 填写月度考勤入口”也统一改为后端 SVG 图标。
去掉了文字图标和本地 CSS 画图标的方式。