### PR TITLE
这次调整： 客户首页“待签考勤”不再使用自己那套迷你日历算法。 改为复用签署/填写页同一个 miniapp/utils/attendance.js 里的：buildCalendar calculateStats normalizeAttendanceData normalizeAutoOvertime

### DIFF
--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -92,7 +92,7 @@ FALLBACK_HOLIDAYS = {
 }
 
 MINIAPP_ICON_SVGS = {
-    "contract_sign": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 14.7V19a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-4.3"/><path d="M14.5 3.5a2.1 2.1 0 0 1 3 3L9.6 14.4 5.5 15.5l1.1-4.1 7.9-7.9Z"/><path d="m13.4 4.6 3 3"/><path d="M7 19c2-2 3.7-2 5 0 1.2 1.7 3 1.6 5.5-.4"/></svg>""",
+    "contract_sign": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22h6a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v10"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10.4 12.6a2 2 0 1 1 3 3L8 21l-4 1 1-4Z"/></svg>""",
     "attendance_fill": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="18" rx="3"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/><path d="M16 18h.01"/></svg>""",
     "evaluation": """<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5 14.7 9l6 .9-4.4 4.2 1 6-5.3-2.8-5.3 2.8 1-6L3.3 9.9l6-.9L12 3.5Z"/><path d="M4 21h16"/></svg>""",
 }
@@ -797,12 +797,12 @@ def _attendance_preview(form, payload=None):
 
     return {
         "work_days": work_days,
-        "work_days_text": _format_attendance_amount(days=work_days),
+        "work_days_text": _format_attendance_result_amount(work_days),
         "leave_days": leave_days,
-        "leave_days_text": _format_attendance_amount(days=leave_days),
+        "leave_days_text": _format_attendance_result_amount(leave_days),
         "overtime_hours": overtime_hours,
         "overtime_days": overtime_days,
-        "overtime_text": _format_attendance_amount(days=overtime_days),
+        "overtime_text": _format_attendance_result_amount(overtime_days),
         "effective_start_date": contract_info.get("start_date"),
         "effective_end_date": contract_info.get("end_date"),
         "calendar_days": days,
@@ -884,8 +884,8 @@ def _attendance_summary(form):
             "leave_count": len(leave_records),
             "overtime_count": len(overtime_records),
             "paid_leave_count": len(paid_leave_records),
-            **preview_stats,
             **(record_stats or {}),
+            **preview_stats,
         },
     }
 

--- a/miniapp/pages/attendance-fill/index.wxml
+++ b/miniapp/pages/attendance-fill/index.wxml
@@ -20,15 +20,14 @@
         <view class="stat-label">出勤(天)</view>
       </view>
       <view class="stat-col">
-        <view class="stat-num orange">{{stats.leaveDaysText}}</view>
-        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
-        <view class="stat-label">请假/休假</view>
-      </view>
-      <view class="stat-col">
         <view class="stat-num green">{{stats.overtimeDaysText}}</view>
         <view wx:if="{{stats.overtimeDaysHoursText}}" class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
         <view class="stat-label">加班(天)</view>
-        
+      </view>
+      <view class="stat-col">
+        <view class="stat-num orange">{{stats.leaveDaysText}}</view>
+        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
+        <view class="stat-label">请假/休假</view>
       </view>
     </view>
   </view>

--- a/miniapp/pages/attendance-sign/index.wxml
+++ b/miniapp/pages/attendance-sign/index.wxml
@@ -19,15 +19,15 @@
         <view class="stat-label">出勤(天)</view>
       </view>
       <view class="stat-col">
-        <view class="stat-num orange">{{stats.leaveDaysText}}</view>
-        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
-        <view class="stat-label">请假/休假</view>
-      </view>
-      <view class="stat-col">
         <view class="stat-num green">{{stats.overtimeDaysText}}</view>
         <view wx:if="{{stats.overtimeDaysHoursText}}" class="stat-hours green">{{stats.overtimeDaysHoursText}}</view>
         <view class="stat-label">加班(天)</view>
         <view wx:if="{{showHolidayOvertimeStat}}" class="stat-sub">含法定 {{stats.holidayOvertimeDaysText}}</view>
+      </view>
+      <view class="stat-col">
+        <view class="stat-num orange">{{stats.leaveDaysText}}</view>
+        <view wx:if="{{stats.leaveDaysHoursText}}" class="stat-hours orange">{{stats.leaveDaysHoursText}}</view>
+        <view class="stat-label">请假/休假</view>
       </view>
     </view>
   </view>

--- a/miniapp/pages/home/index.js
+++ b/miniapp/pages/home/index.js
@@ -1,109 +1,49 @@
 const api = require('../../utils/api');
 const { formatDate, contractView } = require('../../utils/format');
+const {
+  buildCalendar,
+  calculateStats,
+  normalizeAttendanceData,
+  normalizeAutoOvertime
+} = require('../../utils/attendance');
 
-function dateText(value) {
-  return value ? String(value).slice(0, 10) : '';
+function compactDaysText(value) {
+  return String(value || '0').replace(/天$/, '');
 }
 
-function pad(value) {
-  return String(value).padStart(2, '0');
-}
-
-function buildFallbackCalendarDays(item = {}, stats = {}) {
-  const start = new Date(item.cycle_start_date);
-  const end = new Date(item.cycle_end_date);
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return [];
-  const days = [];
-  const cursor = new Date(start.getFullYear(), start.getMonth(), start.getDate());
-  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate());
-  const cycleStartText = dateText(item.cycle_start_date);
-  const cycleEndText = dateText(item.cycle_end_date);
-  const effectiveStart = dateText(stats.effective_start_date);
-  const effectiveEnd = dateText(stats.effective_end_date);
-  const shouldUseEffectiveStart = Boolean(effectiveStart && effectiveStart >= cycleStartText && effectiveStart <= cycleEndText);
-  const shouldUseEffectiveEnd = Boolean(effectiveEnd && effectiveEnd >= cycleStartText && effectiveEnd <= cycleEndText);
-  while (cursor <= last) {
-    const current = `${cursor.getFullYear()}-${pad(cursor.getMonth() + 1)}-${pad(cursor.getDate())}`;
-    const disabled = Boolean(
-      (shouldUseEffectiveStart && current < effectiveStart)
-      || (shouldUseEffectiveEnd && current > effectiveEnd)
-    );
-    days.push({
-      date: current,
-      day: cursor.getDate(),
-      tone: disabled ? 'disabled' : 'normal',
-      label: disabled ? '' : '出勤',
-      disabled
-    });
-    cursor.setDate(cursor.getDate() + 1);
-  }
-  return days;
-}
-
-function normalizeCalendarDay(day, stats = {}) {
-  const current = dateText(day.date);
-  const effectiveStart = dateText(stats.effective_start_date);
-  const effectiveEnd = dateText(stats.effective_end_date);
-  const disabled = Boolean(
-    day.disabled
-    || day.tone === 'disabled'
-  );
-  const tone = disabled ? 'disabled' : (day.tone || 'normal');
+function buildAttendancePreview(item = {}) {
+  const attendanceData = normalizeAttendanceData(item.form_data || {});
+  const firstCalendar = buildCalendar(item, attendanceData, {});
+  const normalizedData = normalizeAutoOvertime(attendanceData, item, firstCalendar.monthDays, {});
+  const calendar = buildCalendar(item, normalizedData, {});
+  const stats = calculateStats(normalizedData, calendar.monthDays, item, {});
   return {
-    ...day,
-    disabled,
-    tone,
-    className: `calendar-day ${tone}`
-  };
-}
-
-function previewDays(days = [], stats = {}) {
-  return (Array.isArray(days) ? days : []).map((item) => normalizeCalendarDay(item, stats));
-}
-
-function formatAmount(value) {
-  const number = Number(value || 0);
-  if (Math.abs(number) < 0.001) return '0';
-  if (Math.abs(number - Math.round(number)) < 0.001) return String(Math.round(number));
-  return number.toFixed(1).replace(/\.0$/, '');
-}
-
-function attendanceCardStats(stats = {}, item = {}) {
-  const hasSavedStats = (
-    stats.work_days_text !== undefined
-    || stats.overtime_text !== undefined
-    || stats.leave_days_text !== undefined
-    || stats.work_days !== undefined
-    || stats.overtime_days !== undefined
-    || stats.leave_days !== undefined
-  );
-  if (hasSavedStats) {
-    return {
-      workDaysText: stats.work_days_text || formatAmount(stats.work_days || 0),
-      overtimeText: stats.overtime_text || formatAmount(stats.overtime_days || 0),
-      leaveDaysText: stats.leave_days_text || formatAmount(stats.leave_days || 0)
-    };
-  }
-
-  const sourceDays = (Array.isArray(stats.calendar_days) && stats.calendar_days.length)
-    ? stats.calendar_days
-    : buildFallbackCalendarDays(item, stats);
-  const days = previewDays(sourceDays, stats);
-  if (!days.length) {
-    return {
-      workDaysText: stats.work_days_text || '0',
-      overtimeText: stats.overtime_text || '0',
-      leaveDaysText: stats.leave_days_text || '0'
-    };
-  }
-
-  const activeDays = days.filter((day) => !day.disabled && day.tone !== 'disabled');
-  const leaveDays = activeDays.filter((day) => day.tone === 'rest').length;
-  const overtimeDays = activeDays.filter((day) => day.tone === 'overtime').length;
-  return {
-    workDaysText: formatAmount(Math.min(26, Math.max(0, activeDays.length - leaveDays))),
-    overtimeText: formatAmount(overtimeDays || stats.overtime_days || 0),
-    leaveDaysText: formatAmount(leaveDays || stats.leave_days || 0)
+    workDaysText: compactDaysText(stats.workDaysText),
+    overtimeText: compactDaysText(stats.overtimeDaysText),
+    leaveDaysText: compactDaysText(stats.leaveDaysText),
+    previewDays: calendar.cells.map((cell) => {
+      if (cell.blank) {
+        return {
+          key: cell.key,
+          blank: true,
+          className: 'calendar-day blank'
+        };
+      }
+      const tone = cell.tone || 'normal';
+      return {
+        ...cell,
+        label: cell.typeLabel,
+        className: [
+          'calendar-day',
+          `tone-${tone}`,
+          cell.weekend ? 'weekend' : '',
+          cell.isHoliday && cell.type === 'normal' ? 'holiday' : '',
+          cell.isWorkday ? 'workday' : '',
+          cell.isAuto ? 'auto-overtime' : '',
+          cell.disabled ? 'disabled' : ''
+        ].filter(Boolean).join(' ')
+      };
+    })
   };
 }
 
@@ -164,16 +104,10 @@ Page({
       }));
       const pendingAttendance = (todos.attendance_forms || []).map((item) => ({
         ...item,
-        ...attendanceCardStats(item.stats || {}, item),
+        ...buildAttendancePreview(item),
         cycle_start_date_text: formatDate(item.cycle_start_date),
         cycle_end_date_text: formatDate(item.cycle_end_date),
-        date_range: `${formatDate(item.cycle_start_date)} - ${formatDate(item.cycle_end_date)}`,
-        preview_days: previewDays(
-          (item.stats && item.stats.calendar_days && item.stats.calendar_days.length)
-            ? item.stats.calendar_days
-            : buildFallbackCalendarDays(item, item.stats || {}),
-          item.stats || {}
-        )
+        date_range: `${formatDate(item.cycle_start_date)} - ${formatDate(item.cycle_end_date)}`
       })).map((item) => ({
         ...item,
         work_days_text: item.workDaysText,

--- a/miniapp/pages/home/index.wxml
+++ b/miniapp/pages/home/index.wxml
@@ -39,11 +39,13 @@
         <view class="attendance-action">去确认</view>
       </view>
       <view class="mini-calendar">
-        <block wx:for="{{item.preview_days}}" wx:for-item="day" wx:key="date">
+        <block wx:for="{{item.previewDays}}" wx:for-item="day" wx:key="key">
           <view class="{{day.className}}">
-            <view class="calendar-num">{{day.day}}</view>
-            <view wx:if="{{day.disabled}}" class="calendar-mark">×</view>
-            <view wx:elif="{{day.label && day.label !== '出勤'}}" class="calendar-mark">{{day.label}}</view>
+            <block wx:if="{{!day.blank}}">
+              <view class="calendar-num">{{day.day}}</view>
+              <view wx:if="{{day.disabled}}" class="calendar-mark">×</view>
+              <view wx:elif="{{day.label && day.label !== '出勤'}}" class="calendar-mark">{{day.label}}</view>
+            </block>
           </view>
         </block>
       </view>

--- a/miniapp/pages/home/index.wxss
+++ b/miniapp/pages/home/index.wxss
@@ -202,24 +202,86 @@
   font-weight: 900;
 }
 
-.calendar-day.rest {
-  background: #fff1f2;
-  color: #dc2626;
-}
-
-.calendar-day.overtime {
-  background: #fef3c7;
-  color: #b45309;
+.calendar-day.blank {
+  background: transparent;
+  border: 0;
 }
 
 .calendar-day.disabled {
-  background: #f8fafc;
-  color: #cbd5e1;
+  background: #f1f5f9;
+  color: #94a3b8;
+  opacity: 0.52;
 }
 
-.calendar-day.normal {
+.calendar-day.weekend {
+  background: #fff1f2;
+}
+
+.calendar-day.holiday {
+  background: #fff1f2;
+  border: 1rpx solid #fecaca;
+}
+
+.calendar-day.workday {
+  background: #eff6ff;
+  border: 1rpx solid #bfdbfe;
+}
+
+.calendar-day.auto-overtime {
+  border: 1rpx dashed #86efac;
+}
+
+.calendar-day.tone-normal {
   background: #e5faf6;
   color: #087c70;
+}
+
+.calendar-day.tone-rest {
+  background: #eff6ff;
+  color: #2563eb;
+  border: 1rpx solid #bfdbfe;
+}
+
+.calendar-day.tone-leave {
+  background: #fefce8;
+  color: #ca8a04;
+  border: 1rpx solid #fde68a;
+}
+
+.calendar-day.tone-overtime {
+  background: #f0fdf4;
+  color: #16a34a;
+  border: 1rpx solid #bbf7d0;
+}
+
+.calendar-day.tone-out-beijing {
+  background: #faf5ff;
+  color: #9333ea;
+  border: 1rpx solid #e9d5ff;
+}
+
+.calendar-day.tone-out-country {
+  background: #fdf2f8;
+  color: #db2777;
+  border: 1rpx solid #fbcfe8;
+}
+
+.calendar-day.tone-paid-leave {
+  background: #eef2ff;
+  color: #4f46e5;
+  border: 1rpx solid #c7d2fe;
+}
+
+.calendar-day.tone-onboarding {
+  background: #ecfeff;
+  color: #0891b2;
+  border: 1rpx solid #a5f3fc;
+}
+
+.calendar-day.tone-offboarding {
+  background: #fff1f2;
+  color: #e11d48;
+  border: 1rpx solid #fecdd3;
 }
 
 .calendar-num {


### PR DESCRIPTION
这样 4 月 1 日会按周三位置显示，日历偏移和签署页一致。
首页小日历的考勤类型颜色也改成和签署/填写页同一套语义色。
首页下方统计也从共用统计逻辑来，不再单独算。
员工填写页、客户签署页顶部统计顺序已改为：出勤 / 加班 / 请假或休假。