### PR TITLE
fix: 修复试工合并考勤上户与加班账单同步

### DIFF
--- a/backend/api/attendance_form_api.py
+++ b/backend/api/attendance_form_api.py
@@ -152,6 +152,166 @@ def get_attendance_contract_end_date(contract):
     return to_date_value(contract.end_date)
 
 
+ATTENDANCE_RECORD_KEYS = [
+    'rest_records',
+    'leave_records',
+    'overtime_records',
+    'out_of_beijing_records',
+    'out_of_country_records',
+    'paid_leave_records',
+    'onboarding_records',
+    'offboarding_records',
+]
+
+
+def _ensure_attendance_record_keys(form_data):
+    changed = False
+    if not isinstance(form_data, dict):
+        form_data = {}
+        changed = True
+    for key in ATTENDANCE_RECORD_KEYS:
+        if key not in form_data:
+            form_data[key] = []
+            changed = True
+    return form_data, changed
+
+
+def _contract_start_date(contract):
+    if not contract:
+        return None
+    actual_onboarding = getattr(contract, 'actual_onboarding_date', None)
+    if actual_onboarding:
+        return to_date_value(actual_onboarding)
+    return to_date_value(contract.start_date)
+
+
+def _same_attendance_family(left, right):
+    if not left or not right:
+        return False
+    if left.family_id:
+        return right.family_id == left.family_id
+    if left.customer_name:
+        return right.customer_name == left.customer_name
+    if left.customer_id:
+        return right.customer_id == left.customer_id
+    return left.id == right.id
+
+
+def _attendance_family_contracts(employee_id, cycle_start, cycle_end, target_contract):
+    if not target_contract:
+        return []
+    contracts = filter_contracts_for_cycle(employee_id, cycle_start, cycle_end)
+    family_contracts = [
+        contract
+        for contract in contracts
+        if _same_attendance_family(target_contract, contract)
+    ]
+    if not any(contract.id == target_contract.id for contract in family_contracts):
+        family_contracts.append(target_contract)
+    return family_contracts
+
+
+def _first_attendance_contract(employee_id, cycle_start, cycle_end, target_contract):
+    family_contracts = _attendance_family_contracts(employee_id, cycle_start, cycle_end, target_contract)
+    candidates = [
+        (contract, _contract_start_date(contract))
+        for contract in family_contracts
+    ]
+    candidates = [
+        (contract, start)
+        for contract, start in candidates
+        if start and cycle_start <= start <= cycle_end
+    ]
+    if not candidates:
+        return None, None
+    return min(candidates, key=lambda item: (item[1], str(item[0].created_at or ""), str(item[0].id)))
+
+
+def ensure_attendance_form_onboarding_record(form, contract=None, effective_start_date=None, mark_modified=True):
+    """Ensure the first day of a merged attendance cycle has an onboarding marker."""
+    if not form:
+        return False
+
+    contract = contract or form.contract
+    if not contract:
+        return False
+
+    cycle_start = to_date_value(form.cycle_start_date)
+    cycle_end = to_date_value(form.cycle_end_date)
+    if not cycle_start or not cycle_end:
+        return False
+
+    first_contract, onboarding_date = _first_attendance_contract(
+        form.employee_id,
+        cycle_start,
+        cycle_end,
+        contract,
+    )
+    if not first_contract and effective_start_date:
+        onboarding_date = to_date_value(effective_start_date)
+        first_contract = contract
+
+    if not onboarding_date or not (cycle_start <= onboarding_date <= cycle_end):
+        return False
+
+    form_data, changed = _ensure_attendance_record_keys(form.form_data or {})
+    onboarding_records = form_data.get('onboarding_records') or []
+    onboarding_date_str = onboarding_date.isoformat()
+    onboarding_label = '试工上户' if getattr(first_contract, 'type', None) == 'nanny_trial' else '上户'
+
+    matching_record = next((item for item in onboarding_records if item.get('date') == onboarding_date_str), None)
+    if matching_record:
+        if matching_record.get('type') != 'onboarding':
+            matching_record['type'] = 'onboarding'
+            changed = True
+        if matching_record.get('label') != onboarding_label:
+            matching_record['label'] = onboarding_label
+            changed = True
+        if first_contract and str(matching_record.get('source_contract_id') or '') != str(first_contract.id):
+            matching_record['source_contract_id'] = str(first_contract.id)
+            matching_record['source_contract_type'] = first_contract.type
+            changed = True
+    else:
+        onboarding_records.append({
+            'date': onboarding_date_str,
+            'type': 'onboarding',
+            'label': onboarding_label,
+            'source_contract_id': str(first_contract.id) if first_contract else str(contract.id),
+            'source_contract_type': first_contract.type if first_contract else contract.type,
+            'startTime': '',
+            'endTime': '',
+            'hours': 0,
+            'minutes': 0,
+            'daysOffset': 0,
+        })
+        changed = True
+
+    form_data['onboarding_records'] = onboarding_records
+    if changed:
+        form.form_data = form_data
+        if mark_modified:
+            flag_modified(form, "form_data")
+    return changed
+
+
+def validate_required_onboarding_times(form_data, cycle_start, cycle_end):
+    errors = []
+    for record in (form_data or {}).get('onboarding_records') or []:
+        raw_date = record.get('date')
+        if not raw_date:
+            continue
+        try:
+            onboarding_date = datetime.fromisoformat(str(raw_date)).date()
+        except (TypeError, ValueError):
+            continue
+        if not (cycle_start <= onboarding_date <= cycle_end):
+            continue
+        label = record.get('label') or '上户'
+        if not record.get('startTime') or not record.get('endTime'):
+            errors.append(f"{label}日 {onboarding_date.strftime('%m月%d日')} 的具体时间未填写")
+    return errors
+
+
 def reconcile_attendance_form_with_contract_end(form):
     """Keep existing attendance forms aligned when a contract is ended early."""
     if not form or not form.contract:
@@ -167,14 +327,8 @@ def reconcile_attendance_form_with_contract_end(form):
         return False
 
     changed = False
-    form_data = form.form_data or {}
-    if not isinstance(form_data, dict):
-        form_data = {}
-    for key in ['rest_records', 'leave_records', 'overtime_records', 'out_of_beijing_records',
-                'out_of_country_records', 'paid_leave_records', 'onboarding_records', 'offboarding_records']:
-        if key not in form_data:
-            form_data[key] = []
-            changed = True
+    form_data, keys_changed = _ensure_attendance_record_keys(form.form_data or {})
+    changed = changed or keys_changed
 
     contract_end_str = contract_end.isoformat()
     offboarding_records = form_data.get('offboarding_records') or []
@@ -793,15 +947,19 @@ def get_attendance_form_by_token(employee_token):
         
         if existing_form:
             reconciled = reconcile_attendance_form_with_contract_end(existing_form)
+            onboarding_reconciled = ensure_attendance_form_onboarding_record(
+                existing_form,
+                contract,
+                effective_start,
+            )
             ensure_confirmed_auto_overtime_for_response(existing_form)
             
             # 检查并补充上户/下户记录（如果缺失）
             form_data = existing_form.form_data or {}
-            form_data_updated = reconciled
+            form_data_updated = reconciled or onboarding_reconciled
             
             # 确保所有记录类型都存在
-            for key in ['rest_records', 'leave_records', 'overtime_records', 'out_of_beijing_records', 
-                        'out_of_country_records', 'paid_leave_records', 'onboarding_records', 'offboarding_records']:
+            for key in ATTENDANCE_RECORD_KEYS:
                 if key not in form_data:
                     form_data[key] = []
                     form_data_updated = True
@@ -826,6 +984,12 @@ def get_attendance_form_by_token(employee_token):
                     })
                     form_data_updated = True
                     current_app.logger.info(f"已存在的考勤表补充上户记录: {contract_start}")
+
+            # 合并试工/正式合同时，上户记录可能来自前置试工合同。
+            # 上面只检查当前合同开始日，这里重新确保合并周期的首个上户日也存在。
+            if ensure_attendance_form_onboarding_record(existing_form, contract, effective_start):
+                form_data = existing_form.form_data or form_data
+                form_data_updated = True
             
             # 检查是否为合同结束月，且缺少下户记录
             
@@ -913,6 +1077,17 @@ def get_attendance_form_by_token(employee_token):
                 current_app.logger.info(f"合同开始月，自动添加上户记录: {contract_start}")
             else:
                 current_app.logger.info(f"续约合同，跳过上户记录: {contract_start}")
+
+        temp_form = AttendanceForm(
+            contract_id=contract.id,
+            employee_id=employee.id,
+            cycle_start_date=cycle_start,
+            cycle_end_date=cycle_end,
+            employee_access_token=access_token,
+            form_data=initial_form_data,
+            status='draft'
+        )
+        ensure_attendance_form_onboarding_record(temp_form, contract, effective_start)
         
         # 判断是否为合同结束月
         # 对于自动月签合同，使用终止日期；否则使用结束日期
@@ -935,15 +1110,7 @@ def get_attendance_form_by_token(employee_token):
             else:
                 current_app.logger.info(f"有续约合同，跳过下户记录: {contract_end_date}")
         
-        new_form = AttendanceForm(
-            contract_id=contract.id,
-            employee_id=employee.id,
-            cycle_start_date=cycle_start,
-            cycle_end_date=cycle_end,
-            employee_access_token=access_token,
-            form_data=initial_form_data,
-            status='draft'
-        )
+        new_form = temp_form
         db.session.add(new_form)
         db.session.commit()
         
@@ -989,9 +1156,9 @@ def update_attendance_form(employee_token):
         action = data.get('action')
         should_apply_auto = action == 'confirm' or form.status == 'employee_confirmed'
         
-        if form_data:
-            form.form_data = form_data
-            if should_apply_auto:
+        if form_data is not None:
+            form.form_data = form_data or {}
+            if should_apply_auto and action != 'confirm':
                 normalized_form_data, normalized = normalize_auto_overtime_form_data(
                     form,
                     allow_create_missing_auto=True,
@@ -1008,21 +1175,22 @@ def update_attendance_form(employee_token):
             
         # 如果是提交确认
         if action == 'confirm':
-            if not form_data:
-                normalized_form_data, normalized = normalize_auto_overtime_form_data(
-                    form,
-                    allow_create_missing_auto=True,
-                )
-                if normalized:
-                    form.form_data = normalized_form_data
-                    form_data = normalized_form_data
-            # 验证"上户"和"下户"记录的时间是否已填写
-            validation_errors = []
-            
-            # 获取合同信息
             contract = BaseContract.query.get(form.contract_id)
             cycle_start = form.cycle_start_date.date() if isinstance(form.cycle_start_date, datetime) else form.cycle_start_date
             cycle_end = form.cycle_end_date.date() if isinstance(form.cycle_end_date, datetime) else form.cycle_end_date
+            _, effective_start, _ = find_consecutive_contracts(form.employee_id, cycle_start, cycle_end)
+            if ensure_attendance_form_onboarding_record(form, contract, effective_start):
+                form_data = form.form_data
+
+            normalized_form_data, normalized = normalize_auto_overtime_form_data(
+                form,
+                allow_create_missing_auto=True,
+            )
+            if normalized:
+                form.form_data = normalized_form_data
+                form_data = normalized_form_data
+            # 验证"上户"和"下户"记录的时间是否已填写
+            validation_errors = []
             
             # 转换合同日期为 date 类型
             contract_start = None
@@ -1047,6 +1215,14 @@ def update_attendance_form(employee_token):
                         validation_errors.append(f"上户日 {contract_start.strftime('%m月%d日')} 的具体时间未填写")
                 else:
                     current_app.logger.info(f"[验证] 续约合同，跳过上户记录验证: {contract_start}")
+
+            validation_errors.extend(
+                validate_required_onboarding_times(
+                    form_data if form_data else form.form_data or {},
+                    cycle_start,
+                    cycle_end,
+                )
+            )
             
             # 检查是否为合同结束月
             contract_end_date = get_attendance_contract_end_date(contract)

--- a/backend/api/miniapp_api.py
+++ b/backend/api/miniapp_api.py
@@ -40,7 +40,9 @@ from backend.api.attendance_form_api import (
     has_following_contract,
     is_continuous_service,
     ensure_confirmed_auto_overtime_for_response,
+    ensure_attendance_form_onboarding_record,
     resolve_effective_attendance_window_for_contract,
+    validate_required_onboarding_times,
 )
 from backend.api.contract_api import _build_signing_messages_payload, handle_signing_page_action
 from backend.services.attendance_sync_service import normalize_auto_overtime_form_data
@@ -1376,6 +1378,12 @@ def _get_or_create_employee_attendance_forms(employee, year=None, month=None):
             (item for item in family_contracts if item.status == "active"),
             max(family_contracts, key=lambda item: item.start_date),
         )
+        service_start = min(
+            (contract.actual_onboarding_date.date() if isinstance(contract.actual_onboarding_date, datetime) else contract.actual_onboarding_date)
+            if contract.actual_onboarding_date
+            else (contract.start_date.date() if isinstance(contract.start_date, datetime) else contract.start_date)
+            for contract in family_contracts
+        )
         form = AttendanceForm.query.filter(
             AttendanceForm.employee_id == employee.id,
             AttendanceForm.cycle_start_date >= cycle_start_dt,
@@ -1393,6 +1401,10 @@ def _get_or_create_employee_attendance_forms(employee, year=None, month=None):
                 form_data={},
                 status="draft",
             )
+            ensure_attendance_form_onboarding_record(form, primary_contract, service_start)
+            db.session.add(form)
+            db.session.flush()
+        elif ensure_attendance_form_onboarding_record(form, primary_contract, service_start):
             db.session.add(form)
             db.session.flush()
         forms.append(form)
@@ -2263,7 +2275,7 @@ def employee_attendance_update(form_id):
     should_apply_auto = action == "confirm" or form.status == "employee_confirmed"
     if form_data is not None:
         form.form_data = form_data or {}
-        if should_apply_auto:
+        if should_apply_auto and action != "confirm":
             normalized_form_data, normalized = normalize_auto_overtime_form_data(
                 form,
                 allow_create_missing_auto=True,
@@ -2278,20 +2290,22 @@ def employee_attendance_update(form_id):
         flag_modified(form, "form_data")
 
     if action == "confirm":
-        if form_data is None:
-            normalized_form_data, normalized = normalize_auto_overtime_form_data(
-                form,
-                allow_create_missing_auto=True,
-            )
-            if normalized:
-                form.form_data = normalized_form_data
-                flag_modified(form, "form_data")
-
-        validation_errors = []
         contract = BaseContract.query.get(form.contract_id)
         cycle_start = form.cycle_start_date.date() if isinstance(form.cycle_start_date, datetime) else form.cycle_start_date
         cycle_end = form.cycle_end_date.date() if isinstance(form.cycle_end_date, datetime) else form.cycle_end_date
+        _, effective_start, _ = find_consecutive_contracts(form.employee_id, cycle_start, cycle_end)
+        if ensure_attendance_form_onboarding_record(form, contract, effective_start):
+            flag_modified(form, "form_data")
 
+        normalized_form_data, normalized = normalize_auto_overtime_form_data(
+            form,
+            allow_create_missing_auto=True,
+        )
+        if normalized:
+            form.form_data = normalized_form_data
+            flag_modified(form, "form_data")
+
+        validation_errors = []
         contract_start = None
         if contract and contract.start_date:
             contract_start = contract.start_date.date() if isinstance(contract.start_date, datetime) else contract.start_date
@@ -2306,6 +2320,14 @@ def employee_attendance_update(form_id):
                 validation_errors.append(f"合同开始日 {contract_start.strftime('%m月%d日')} 需要填写「上户」记录")
             elif not onboarding_record.get("startTime") or not onboarding_record.get("endTime"):
                 validation_errors.append(f"上户日 {contract_start.strftime('%m月%d日')} 的具体时间未填写")
+
+        validation_errors.extend(
+            validate_required_onboarding_times(
+                current_form_data,
+                cycle_start,
+                cycle_end,
+            )
+        )
 
         contract_end_date = get_attendance_contract_end_date(contract)
 

--- a/backend/services/attendance_sync_service.py
+++ b/backend/services/attendance_sync_service.py
@@ -702,8 +702,7 @@ def sync_attendance_to_record(attendance_form_id):
     onboarding_records = data.get('onboarding_records', [])
     offboarding_records = data.get('offboarding_records', [])
     
-    # 上户月不把上户当天计入基础出勤；该日剩余小时留到下户月合并计算。
-    onboarding_days = _onboarding_days_to_exclude(data, cycle_start, cycle_end, form.contract)
+    onboarding_days = Decimal(0)
     
     # 下户月需要把首月上户日剩余小时与下户日已工作小时合并计算。
     offboarding_days = Decimal(0)
@@ -778,8 +777,15 @@ def sync_attendance_to_record(attendance_form_id):
         current_app.logger.info(f"[ATTENDANCE_SYNC] 合同有效期: {effective_start} 到 {effective_end}, 基础劳务天数: {base_work_days}")
     else:
         # 如果没有合同信息，回退到使用考勤周期
+        effective_start = cycle_start
+        effective_end = cycle_end
         base_work_days = (cycle_end - cycle_start).days + 1
         current_app.logger.warning(f"[ATTENDANCE_SYNC] 未找到合同信息，使用考勤周期天数: {base_work_days}")
+
+    # 上户月不把上户当天计入基础出勤；该日剩余小时留到下户月合并计算。
+    # 合并试工/正式考勤时，试工上户日可能早于当前正式合同账单周期，
+    # 只在当前合同实际计薪窗口内扣减，避免正式账单基础劳务天数被多扣一天。
+    onboarding_days = _onboarding_days_to_exclude(data, effective_start, effective_end, form.contract)
     
     # 出勤天数 = 基础劳务天数 - 休息天数 - 请假天数 - 上户日 + 末月小时合并调整
     if offboarding_records and offboarding_day_work > 0:

--- a/backend/services/billing_engine.py
+++ b/backend/services/billing_engine.py
@@ -2421,6 +2421,13 @@ class BillingEngine:
                 cycle_start_date,
                 cycle_end_date,
             )
+        elif not attendance.attendance_form_id:
+            attendance = self._apply_monthly_form_to_attendance(
+                attendance,
+                contract,
+                cycle_start_date,
+                cycle_end_date,
+            ) or attendance
 
         if not attendance:
             employee_id = contract.service_personnel_id
@@ -2489,7 +2496,7 @@ class BillingEngine:
                 return str(form_contract.customer_id) == str(contract.customer_id)
             return bool(contract.customer_name and form_contract.customer_name == contract.customer_name)
 
-        signed_form = next((form for form in candidate_forms if same_family_or_customer(form)), None)
+        signed_form = self._find_signed_monthly_attendance_form(contract, cycle_start, candidate_forms)
         if not signed_form or not signed_form.form_data:
             return None
 
@@ -2506,6 +2513,65 @@ class BillingEngine:
         self._apply_attendance_allocation(attendance, signed_form, cycle_start, cycle_end)
         db.session.flush()
         return attendance
+
+    def _apply_monthly_form_to_attendance(self, attendance, contract, cycle_start_date, cycle_end_date):
+        cycle_start = self._to_date(cycle_start_date)
+        cycle_end = self._to_date(cycle_end_date)
+        if not cycle_start or not cycle_end:
+            return None
+
+        month_start = date(cycle_start.year, cycle_start.month, 1)
+        next_month_start = (
+            date(cycle_start.year + 1, 1, 1)
+            if cycle_start.month == 12
+            else date(cycle_start.year, cycle_start.month + 1, 1)
+        )
+        candidate_forms = AttendanceForm.query.filter(
+            AttendanceForm.employee_id == contract.service_personnel_id,
+            AttendanceForm.cycle_start_date >= month_start,
+            AttendanceForm.cycle_start_date < next_month_start,
+            AttendanceForm.status.in_(["customer_signed", "synced"]),
+        ).order_by(AttendanceForm.updated_at.desc().nullslast(), AttendanceForm.created_at.desc()).all()
+
+        signed_form = self._find_signed_monthly_attendance_form(contract, cycle_start, candidate_forms)
+        if not signed_form or not signed_form.form_data:
+            return None
+
+        attendance.attendance_form_id = signed_form.id
+        self._apply_attendance_allocation(attendance, signed_form, cycle_start, cycle_end)
+        db.session.flush()
+        return attendance
+
+    def _find_signed_monthly_attendance_form(self, contract, cycle_start, candidate_forms):
+        def same_family_or_customer(form):
+            form_contract = form.contract
+            if not form_contract:
+                return False
+            if str(form_contract.id) == str(contract.id):
+                return True
+            if contract.family_id and form_contract.family_id:
+                return form_contract.family_id == contract.family_id
+            if contract.customer_id and form_contract.customer_id:
+                return str(form_contract.customer_id) == str(contract.customer_id)
+            return bool(contract.customer_name and form_contract.customer_name == contract.customer_name)
+
+        matching_forms = [form for form in candidate_forms if same_family_or_customer(form)]
+        exact_form = next(
+            (
+                form for form in matching_forms
+                if str(form.contract_id) == str(contract.id)
+            ),
+            None,
+        )
+        if exact_form:
+            return exact_form
+        return next(
+            (
+                form for form in matching_forms
+                if self._to_date(form.cycle_start_date) <= cycle_start <= self._to_date(form.cycle_end_date)
+            ),
+            None,
+        )
 
     def _attendance_days_in_cycle(self, records, cycle_start, cycle_end):
         total = D(0)

--- a/frontend/src/components/attendance/AttendanceFillPage.jsx
+++ b/frontend/src/components/attendance/AttendanceFillPage.jsx
@@ -673,7 +673,8 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
         type: 'normal',
         daysOffset: 0,
         startTime: '09:00',
-        endTime: '18:00'
+        endTime: '18:00',
+        label: ''
     });
 
     // Scroll state for header shrink effect
@@ -975,7 +976,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             if (key.endsWith('_records') && Array.isArray(attendanceData[key])) {
                 attendanceData[key].forEach(record => {
                     const recordType = record.type || key.replace('_records', '');
-                    if (recordType === 'onboarding' && !record.startTime) return;
+                    if (recordType === 'onboarding' && !record.startTime && !record.label) return;
                     if (recordType === 'offboarding' && !record.endTime) return;
 
                     // 【关键修复】计算当前月份内的实际天数
@@ -1026,7 +1027,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                     allRecords.push({
                         ...record,
                         type: recordType,
-                        typeLabel: ATTENDANCE_TYPES[Object.keys(ATTENDANCE_TYPES).find(k => ATTENDANCE_TYPES[k].value === recordType)]?.label,
+                        typeLabel: record.label || ATTENDANCE_TYPES[Object.keys(ATTENDANCE_TYPES).find(k => ATTENDANCE_TYPES[k].value === recordType)]?.label,
                         // 【关键】使用当前月份内的时长
                         hours: hoursInCurrentMonth,
                         minutes: minutesInCurrentMonth,
@@ -1094,7 +1095,7 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             result = {
                 ...displayResult.record,
                 type: displayResult.type,
-                typeLabel: displayResult.typeLabel,
+                typeLabel: displayResult.record?.label || displayResult.typeLabel,
                 typeConfig: ATTENDANCE_TYPES[Object.keys(ATTENDANCE_TYPES).find(k => ATTENDANCE_TYPES[k].value === displayResult.type)],
                 hours: Math.floor(totalHours),
                 minutes: Math.round((totalHours % 1) * 60),
@@ -1218,7 +1219,10 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                 // 下户：startTime 显示的是离开时间（即 endTime）
                 // 上户/其他：保留原始 startTime
                 startTime: isOffboarding ? (originalRecord.endTime || '') : (originalRecord.startTime || ''),
-                endTime: originalRecord.endTime || ''
+                endTime: originalRecord.endTime || '',
+                label: originalRecord.label || '',
+                source_contract_id: originalRecord.source_contract_id,
+                source_contract_type: originalRecord.source_contract_type
             });
         } else {
             // 没有找到原始记录，使用默认值
@@ -1226,7 +1230,8 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                 type: 'normal',
                 daysOffset: 0,
                 startTime: '09:00',
-                endTime: '18:00'
+                endTime: '18:00',
+                label: ''
             });
         }
 
@@ -1494,6 +1499,13 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
             // If not normal, add to the new list
             if (tempRecord.type !== 'normal') {
                 const recordKey = `${tempRecord.type}_records`;
+                const preservedOnboardingFields = tempRecord.type === 'onboarding'
+                    ? {
+                        ...(tempRecord.label ? { label: tempRecord.label } : {}),
+                        ...(tempRecord.source_contract_id ? { source_contract_id: tempRecord.source_contract_id } : {}),
+                        ...(tempRecord.source_contract_type ? { source_contract_type: tempRecord.source_contract_type } : {})
+                    }
+                    : {};
                 newData[recordKey] = [...(newData[recordKey] || []), {
                     date: actualStartDateStr, // 出京/出境使用计算后的开始日期
                     hours: calculatedDuration.hours,
@@ -1501,7 +1513,8 @@ const AttendanceFillPage = ({ mode = 'employee' }) => {
                     type: tempRecord.type,
                     daysOffset: actualDaysOffset,
                     startTime: startTime,
-                    endTime: endTime
+                    endTime: endTime,
+                    ...preservedOnboardingFields
                 }];
             }
 

--- a/scripts/fix_june_holiday_overtime_billing.py
+++ b/scripts/fix_june_holiday_overtime_billing.py
@@ -16,6 +16,7 @@ import sys
 from copy import deepcopy
 from decimal import Decimal
 from pathlib import Path
+from types import SimpleNamespace
 
 from dotenv import load_dotenv
 from sqlalchemy.orm.attributes import flag_modified
@@ -29,6 +30,7 @@ logging.disable(logging.WARNING)
 
 from backend.app import app
 from backend.models import AttendanceForm, AttendanceRecord, BaseContract, CustomerBill, EmployeePayroll, db
+from backend.api.attendance_form_api import ensure_attendance_form_onboarding_record
 from backend.services.attendance_sync_service import (
     _parse_date,
     _record_covers_day,
@@ -120,6 +122,28 @@ def has_june_statutory_overtime(form_data):
         return Decimal("0")
 
 
+def form_snapshot(form, form_data):
+    return SimpleNamespace(
+        id=form.id,
+        contract=form.contract,
+        contract_id=form.contract_id,
+        employee_id=form.employee_id,
+        cycle_start_date=form.cycle_start_date,
+        cycle_end_date=form.cycle_end_date,
+        form_data=deepcopy(form_data or {}),
+    )
+
+
+def preview_onboarding_reconcile(form):
+    snapshot = form_snapshot(form, form.form_data or {})
+    changed = ensure_attendance_form_onboarding_record(
+        snapshot,
+        form.contract,
+        mark_modified=False,
+    )
+    return changed, snapshot.form_data
+
+
 def needs_manual_holiday_review(form):
     holiday_date = _parse_date("2026-06-19")
     try:
@@ -146,8 +170,10 @@ def analyze_form(form):
     cycle_start = _parse_date(form.cycle_start_date)
     cycle_end = _parse_date(form.cycle_end_date)
     original_data = deepcopy(form.form_data or {})
+    onboarding_changed, onboarding_data = preview_onboarding_reconcile(form)
+    normalized_form = form_snapshot(form, onboarding_data)
     normalized_data, normalized_changed = normalize_auto_overtime_form_data(
-        form,
+        normalized_form,
         allow_create_missing_auto=True,
     )
     normal_days, holiday_days = _split_overtime_days_by_holiday(normalized_data, cycle_start, cycle_end)
@@ -178,7 +204,8 @@ def analyze_form(form):
     record_mismatch = not same_days(expected_overtime_days, record_overtime)
     record_needs_normalize = record_has_legacy_holiday and not same_days(record_field_total, record_overtime)
     needs_resync = (
-        normalized_changed
+        onboarding_changed
+        or normalized_changed
         or record_mismatch
         or bill_mismatch
         or record_needs_normalize
@@ -190,6 +217,7 @@ def analyze_form(form):
         "original_data": original_data,
         "normalized_data": normalized_data,
         "normalized_changed": normalized_changed,
+        "onboarding_changed": onboarding_changed,
         "holiday_days": holiday_days,
         "normal_days": normal_days,
         "expected_overtime_days": expected_overtime_days,
@@ -228,6 +256,14 @@ def print_case(case, host, index):
         original_count = len((case["original_data"] or {}).get("overtime_records") or [])
         new_count = len((case["normalized_data"] or {}).get("overtime_records") or [])
         print(f"自动补齐: 将更新 overtime_records 数量 {original_count} -> {new_count}")
+    if case["onboarding_changed"]:
+        onboarding_records = (case["normalized_data"] or {}).get("onboarding_records") or []
+        trial_labels = [
+            f"{item.get('date')} {item.get('label') or '上户'}"
+            for item in onboarding_records
+            if item.get("source_contract_type") == "nanny_trial" or item.get("label") == "试工上户"
+        ]
+        print(f"试工上户: 将补充/更新 {', '.join(trial_labels) if trial_labels else '上户记录'}")
     if not case["bill"]:
         print("提示: 未找到 2026-06 主账单，apply 只会同步考勤，无法重算对应账单")
 
@@ -329,13 +365,14 @@ def main():
         applied = 0
         for case in actionable:
             form = case["form"]
+            form.form_data = case["normalized_data"]
+            flag_modified(form, "form_data")
+            db.session.add(form)
+            db.session.flush()
             if form.status in ("customer_signed", "synced"):
                 sync_attendance_to_record(form.id)
                 applied += 1
             else:
-                form.form_data = case["normalized_data"]
-                flag_modified(form, "form_data")
-                db.session.add(form)
                 db.session.commit()
                 applied += 1
 


### PR DESCRIPTION
- 合并试工与正式合同考勤周期时自动补充“试工上户”记录
- 确认考勤时先补齐上户记录，再重新计算自动加班
- Web 考勤详情优先展示记录 label，并保留试工上户元数据
- 账单计算支持从整月已签署考勤表分配月中合同加班
- 扩展 6 月法定节假日修复脚本，支持 dry-run/apply 补试工上户
- 限制上户日扣减在当前合同计薪窗口内，避免正式合同基础劳务天数被误扣